### PR TITLE
CsvReader cleanups: Immutables, fix Executor cleanup, shrink dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ java {
 
 dependencies {
     implementation 'ch.randelshofer:fastdoubleparser:0.3.0'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 
     testImplementation 'net.sf.trove4j:trove4j:3.0.3'

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ dependencies {
     implementation 'ch.randelshofer:fastdoubleparser:0.3.0'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 
+    annotationProcessor 'org.immutables:value:2.8.8'
+    compileOnly 'org.immutables:value-annotations:2.8.8'
+
     testImplementation 'net.sf.trove4j:trove4j:3.0.3'
     testImplementation 'commons-io:commons-io:2.11.0'
     testCompileOnly 'org.jetbrains:annotations:23.0.0'

--- a/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnParserDeephaven.java
@@ -1,23 +1,27 @@
 package io.deephaven.csv.benchmark.intcol;
 
+import io.deephaven.csv.CsvSpecs;
 import io.deephaven.csv.parsers.IntParser;
+import io.deephaven.csv.parsers.Parsers;
 import io.deephaven.csv.reading.CsvReader;
 import io.deephaven.csv.sinks.SinkFactory;
 import io.deephaven.csvbench.MySinkFactory;
 import io.deephaven.csvbench.MySinkFactory.ResultProvider;
 
 import java.io.InputStream;
+import java.util.List;
 
 public final class IntColumnParserDeephaven implements IntColumnParser {
 
     @Override
     public ResultProvider<int[]> read(InputStream in) throws Exception {
         final SinkFactory sinkFactory = MySinkFactory.create();
-        final CsvReader reader = new CsvReader()
-                .setParserFor(0, IntParser.INSTANCE)
-                .setHasHeaders(true)
-                .setHeaders("X");
-        final CsvReader.Result result = reader.read(in, sinkFactory);
+        final CsvSpecs specs = CsvSpecs.builder()
+                .putParserForIndex(0, Parsers.INT)
+                .hasHeaderRow(true)
+                .headers(List.of("X"))
+                .build();
+        final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         // noinspection unchecked
         return (ResultProvider<int[]>) result.columns()[0];
     }

--- a/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnParserRowOriented.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnParserRowOriented.java
@@ -2,9 +2,9 @@ package io.deephaven.csv.benchmark.intcol;
 
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.sinks.SinkFactory;
+import io.deephaven.csv.util.MutableObject;
 import io.deephaven.csvbench.MySinkFactory;
 import io.deephaven.csvbench.MySinkFactory.ResultProvider;
-import org.apache.commons.lang3.mutable.MutableObject;
 
 import java.io.InputStream;
 import java.util.Objects;

--- a/src/jmh/java/io/deephaven/csvbench/BenchmarkDateTimes.java
+++ b/src/jmh/java/io/deephaven/csvbench/BenchmarkDateTimes.java
@@ -68,9 +68,10 @@ public class BenchmarkDateTimes implements KosakianBenchmark {
     }
 
     public void deephaven() throws io.deephaven.csv.util.CsvReaderException {
-        final io.deephaven.csv.reading.CsvReader reader = new io.deephaven.csv.reading.CsvReader();
+        final io.deephaven.csv.CsvSpecs specs = io.deephaven.csv.CsvSpecs.csv();
         final io.deephaven.csv.sinks.SinkFactory sf = MySinkFactory.create();
-        final io.deephaven.csv.reading.CsvReader.Result result = reader.read(tableTextStream, sf);
+        final io.deephaven.csv.reading.CsvReader.Result result =
+                io.deephaven.csv.reading.CsvReader.read(specs, tableTextStream, sf);
 
         actualResult = new long[NUM_COLS][];
         for (int ii = 0; ii < NUM_COLS; ++ii) {

--- a/src/jmh/java/io/deephaven/csvbench/BenchmarkDoubles.java
+++ b/src/jmh/java/io/deephaven/csvbench/BenchmarkDoubles.java
@@ -56,9 +56,10 @@ public class BenchmarkDoubles implements KosakianBenchmark {
     }
 
     public void deephaven() throws io.deephaven.csv.util.CsvReaderException {
-        final io.deephaven.csv.reading.CsvReader reader = new io.deephaven.csv.reading.CsvReader();
+        final io.deephaven.csv.CsvSpecs specs = io.deephaven.csv.CsvSpecs.csv();
         final io.deephaven.csv.sinks.SinkFactory sf = MySinkFactory.create();
-        final io.deephaven.csv.reading.CsvReader.Result result = reader.read(tableTextStream, sf);
+        final io.deephaven.csv.reading.CsvReader.Result result =
+                io.deephaven.csv.reading.CsvReader.read(specs, tableTextStream, sf);
 
         actualResult = new double[NUM_COLS][];
         for (int ii = 0; ii < NUM_COLS; ++ii) {

--- a/src/jmh/java/io/deephaven/csvbench/BenchmarkInts.java
+++ b/src/jmh/java/io/deephaven/csvbench/BenchmarkInts.java
@@ -56,9 +56,10 @@ public class BenchmarkInts implements KosakianBenchmark {
     }
 
     public void deephaven() throws io.deephaven.csv.util.CsvReaderException {
-        final io.deephaven.csv.reading.CsvReader reader = new io.deephaven.csv.reading.CsvReader();
+        final io.deephaven.csv.CsvSpecs specs = io.deephaven.csv.CsvSpecs.csv();
         final io.deephaven.csv.sinks.SinkFactory sf = MySinkFactory.create();
-        final io.deephaven.csv.reading.CsvReader.Result result = reader.read(tableTextStream, sf);
+        final io.deephaven.csv.reading.CsvReader.Result result =
+                io.deephaven.csv.reading.CsvReader.read(specs, tableTextStream, sf);
 
         actualResult = new int[NUM_COLS][];
         for (int ii = 0; ii < NUM_COLS; ++ii) {

--- a/src/jmh/java/io/deephaven/csvbench/BenchmarkStrings.java
+++ b/src/jmh/java/io/deephaven/csvbench/BenchmarkStrings.java
@@ -58,9 +58,10 @@ public class BenchmarkStrings implements KosakianBenchmark {
     }
 
     public void deephaven() throws io.deephaven.csv.util.CsvReaderException {
-        final io.deephaven.csv.reading.CsvReader reader = new io.deephaven.csv.reading.CsvReader();
+        final io.deephaven.csv.CsvSpecs specs = io.deephaven.csv.CsvSpecs.csv();
         final io.deephaven.csv.sinks.SinkFactory sf = MySinkFactory.create();
-        final io.deephaven.csv.reading.CsvReader.Result result = reader.read(tableTextStream, sf);
+        final io.deephaven.csv.reading.CsvReader.Result result =
+                io.deephaven.csv.reading.CsvReader.read(specs, tableTextStream, sf);
 
         actualResult = new String[NUM_COLS][];
         for (int ii = 0; ii < NUM_COLS; ++ii) {

--- a/src/main/java/io/deephaven/csv/CsvSpecs.java
+++ b/src/main/java/io/deephaven/csv/CsvSpecs.java
@@ -1,0 +1,250 @@
+package io.deephaven.csv;
+
+import io.deephaven.csv.annotations.BuildableStyle;
+import io.deephaven.csv.parsers.Parser;
+import io.deephaven.csv.parsers.Parsers;
+import io.deephaven.csv.tokenization.Tokenizer;
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A specification object for parsing CSV input.
+ */
+@Immutable
+@BuildableStyle
+public abstract class CsvSpecs {
+
+    public interface Builder {
+        Builder headers(Iterable<String> elements);
+
+        Builder putHeaderForIndex(int index, String header);
+
+        Builder parsers(Iterable<? extends Parser<?>> elements);
+
+        Builder putParserForName(String columnName, Parser<?> parser);
+
+        Builder putParserForIndex(int index, Parser<?> parser);
+
+        Builder nullValueLiteral(String nullValueLiteral);
+
+        Builder putNullValueLiteralForName(String columnName, String nullValueLiteral);
+
+        Builder putNullValueLiteralForIndex(int index, String nullValueLiteral);
+
+        Builder nullParser(Parser<?> parser);
+
+        Builder hasHeaderRow(boolean hasHeaderRow);
+
+        Builder delimiter(char delimiter);
+
+        Builder quote(char quote);
+
+        Builder ignoreSurroundingSpaces(boolean ignoreSurroundingSpaces);
+
+        Builder trim(boolean trim);
+
+        Builder concurrent(boolean async);
+
+        Builder customTimeZoneParser(Tokenizer.CustomTimeZoneParser customTimeZoneParser);
+
+        CsvSpecs build();
+    }
+
+    /**
+     * Creates a builder for {@link CsvSpecs}.
+     */
+    public static Builder builder() {
+        return ImmutableCsvSpecs.builder();
+    }
+
+    /**
+     * A comma-separated-value delimited format.
+     */
+    public static CsvSpecs csv() {
+        return builder().build();
+    }
+
+    /**
+     * A tab-separated-value delimited format. Equivalent to {@code builder().delimiter('\t').build()}.
+     */
+    public static CsvSpecs tsv() {
+        return builder().delimiter('\t').build();
+    }
+
+    /**
+     * A header-less, CSV format. Equivalent to {@code builder().hasHeaderRow(false).build()}.
+     */
+    public static CsvSpecs headerless() {
+        return builder().hasHeaderRow(false).build();
+    }
+
+    /**
+     * Client-specified headers that can be used to override the existing headers in the input (if
+     * {@link #hasHeaderRow()} is true), or to provide absent headers (if {@link #hasHeaderRow()} is false).
+     */
+    public abstract List<String> headers();
+
+    /**
+     * Override a specific column header by number. This is applied after {@link #headers()}. Column numbers start with
+     * 1.
+     */
+    public abstract Map<Integer, String> headerForIndex();
+
+    /**
+     * Used to force a specific parser for a specific column, specified by column name. Specifying a parser forgoes
+     * column inference for that column.
+     */
+    public abstract Map<String, Parser<?>> parserForName();
+
+    /**
+     * The parsers that the user wants to participate in type inference. Note that the order that the parsers in this
+     * list matters only for custom parsers. In particular:
+     * <ol>
+     * <li>Standard system parsers (singletons from the {@link Parsers} class) will run in their standard precedence
+     * order, regardless of the order they appear here.</li>
+     * <li>All specified system parsers will be run before any specified custom parsers.</li>
+     * <li>Custom parsers will be run in the order they are specified here.</li>
+     * </ol>
+     *
+     * @return the parsers
+     */
+    @Default
+    public List<Parser<?>> parsers() {
+        return Parsers.DEFAULT;
+    }
+
+    /**
+     * Used to force a specific parser for a specific column, specified by column number. Column numbers start with 1.
+     * Specifying a parser forgoes column inference for that column.
+     */
+    public abstract Map<Integer, Parser<?>> parserForIndex();
+
+    /**
+     * The default string that means "null value" in the input. This default is used for a column if there is no
+     * corresponding {@link #nullValueLiteralForName()} or {@link #nullValueLiteralForName()} specified for that column.
+     */
+    @Default
+    public String nullValueLiteral() {
+        return "";
+    }
+
+    /**
+     * The null value literal for specific columns, specified by column name. Specifying a null value literal for a
+     * column overrides the value in {@link #nullValueLiteral()}.
+     */
+    public abstract Map<String, String> nullValueLiteralForName();
+
+    /**
+     * The null value literal for specific columns, specified by 1-based column index. Specifying a null value literal
+     * for a column overrides the value in {@link #nullValueLiteral()}.
+     */
+    public abstract Map<Integer, String> nullValueLiteralForIndex();
+
+    /**
+     * The parser to uses when all values in the column are null. Defaults to {@code Parsers#STRING}.
+     */
+    @Default
+    @Nullable
+    public Parser<?> nullParser() {
+        return Parsers.STRING;
+    }
+
+    /**
+     * An optional low-level parser that understands custom time zones.
+     */
+    @Default
+    @Nullable
+    public Tokenizer.CustomTimeZoneParser customTimeZoneParser() {
+        return null;
+    }
+
+    /**
+     * An optional legalizer for column headers. The legalizer is a function that takes column names (as a
+     * {@code String[]}) names and returns legal column names (as a {@code String[]}). The legalizer function is
+     * permitted to reuse its input data structure. Defaults to {@code Function#identity()}.
+     */
+    @Default
+    public Function<String[], String[]> headerLegalizer() {
+        return Function.identity();
+    }
+
+    /**
+     * An optional validator for column headers. The validator is a {@link Predicate} function that takes a column name
+     * and returns a true if it is a legal column name, false otherwise. Defaults to {@code c -> true}.
+     */
+    @Default
+    public Predicate<String> headerValidator() {
+        return c -> true;
+    }
+
+    /**
+     * The header row flag. If {@code true}, the column names of the output table will be inferred from the first row of
+     * the table. If {@code false}, the column names will be numbered numerically in the format "Column%d" with a
+     * 1-based index. Defaults to {@code true}.
+     */
+    @Default
+    public boolean hasHeaderRow() {
+        return true;
+    }
+
+    /**
+     * The field delimiter character (the character that separates one column from the next). Must be 7-bit ASCII.
+     * Defaults to {code ','}.
+     */
+    @Default
+    public char delimiter() {
+        return ',';
+    }
+
+    /**
+     * The quote character (used when you want field or line delimiters to be interpreted as literal text. Must be 7-bit
+     * ASCII. Defaults to {@code '"'}. For example:
+     *
+     * <pre>
+     * 123,"hello, there",456,
+     * </pre>
+     *
+     * Would be read as the three fields:
+     *
+     * <ul>
+     * <li>123
+     * <li>hello, there
+     * <li>456
+     * </ul>
+     */
+    @Default
+    public char quote() {
+        return '"';
+    }
+
+    /**
+     * Whether to trim leading and trailing blanks from non-quoted values. Defaults to {@code true}.
+     */
+    @Default
+    public boolean ignoreSurroundingSpaces() {
+        return true;
+    }
+
+    /**
+     * Whether to trim leading and trailing blanks from inside quoted values. Defaults to {@code false}.
+     */
+    @Default
+    public boolean trim() {
+        return false;
+    }
+
+    /**
+     * Whether to run concurrently. In particular, the operation that reads the raw file, breaks it into columns, and
+     * stores that column text in memory can run in parallel with the column parsers, and the parsers can run in
+     * parallel with each other.
+     */
+    @Default
+    public boolean concurrent() {
+        return true;
+    }
+}

--- a/src/main/java/io/deephaven/csv/annotations/BuildableStyle.java
+++ b/src/main/java/io/deephaven/csv/annotations/BuildableStyle.java
@@ -1,0 +1,21 @@
+package io.deephaven.csv.annotations;
+
+import org.immutables.value.Value;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A simple style is for objects that are simple to build. Not recommended for objects with more than two fields. Not
+ * applicable for objects with default fields.
+ */
+@Target({ElementType.TYPE, ElementType.PACKAGE})
+@Retention(RetentionPolicy.CLASS)
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE,
+        defaults = @Value.Immutable(copy = false), strictBuilder = false, weakInterning = true,
+        jdkOnly = true)
+public @interface BuildableStyle {
+    // Note: this produces ImmutableX.builder()s for the implementation classes
+}

--- a/src/main/java/io/deephaven/csv/densestorage/DenseStorageReader.java
+++ b/src/main/java/io/deephaven/csv/densestorage/DenseStorageReader.java
@@ -2,7 +2,7 @@ package io.deephaven.csv.densestorage;
 
 import io.deephaven.csv.containers.ByteSlice;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableInt;
+import io.deephaven.csv.util.MutableInt;
 
 /** Companion to the {@link DenseStorageWriter}. See the documentation there for details. */
 public final class DenseStorageReader {

--- a/src/main/java/io/deephaven/csv/densestorage/DenseStorageWriter.java
+++ b/src/main/java/io/deephaven/csv/densestorage/DenseStorageWriter.java
@@ -122,17 +122,13 @@ public final class DenseStorageWriter {
             fctrl = controlWriter.addInt(size);
         }
         // If the control queue flushed, then flush all the data queues, so the reader doesn't block for
-        // a long time
-        // waiting for some unflushed data queue. One might worry this this is inefficient, but (a) it
-        // doesn't happen
-        // very often and (b) in our queue code, partially-filled blocks can share non-overlapping parts
-        // of their
-        // large underlying data array, so it's not too wasteful. Put another way, flushing an empty
-        // queue does nothing;
-        // flushing a partially-filled queue allocates a new QueueNode but not a new underlying data
-        // array;
-        // flushing a full queue will allocates a new QueueNode and (at the next write) a new underlying
-        // data array.
+        // a long time waiting for some unflushed data queue. One might worry it s inefficient to flush
+        // a data queue that is not full, but (a) in practice it doesn't happen very often and (b) in
+        // our queue code, partially-filled blocks can share non-overlapping parts (slices) of their
+        // underlying storage array, so it's not particularly wasteful. Put another way, flushing an
+        // empty queue does nothing; flushing a partially-filled queue allocates a new QueueNode but
+        // not a new underlying data array; flushing a full queue will allocated a new QueueNode and
+        // (lazily deferred until the next write) a new underlying data array.
         if (fctrl) {
             byteWriter.flush();
             largeByteArrayWriter.flush();

--- a/src/main/java/io/deephaven/csv/densestorage/QueueReader.java
+++ b/src/main/java/io/deephaven/csv/densestorage/QueueReader.java
@@ -1,7 +1,7 @@
 package io.deephaven.csv.densestorage;
 
 import io.deephaven.csv.containers.ByteSlice;
-import org.apache.commons.lang3.mutable.MutableInt;
+import io.deephaven.csv.util.MutableInt;
 
 /** Companion to the {@link QueueWriter}. See the documentation there for details. */
 public class QueueReader<TARRAY> {

--- a/src/main/java/io/deephaven/csv/densestorage/QueueReader.java
+++ b/src/main/java/io/deephaven/csv/densestorage/QueueReader.java
@@ -97,7 +97,8 @@ public class QueueReader<TARRAY> {
         try {
             o.wait();
         } catch (InterruptedException ie) {
-            throw new RuntimeException("Logic error: thread interrupted: can't happen");
+            throw new RuntimeException(
+                    "Thread interrupted: probably cancelled in the CsvReader class due to some other exception.");
         }
     }
 

--- a/src/main/java/io/deephaven/csv/densestorage/QueueWriter.java
+++ b/src/main/java/io/deephaven/csv/densestorage/QueueWriter.java
@@ -42,8 +42,8 @@ public class QueueWriter<TARRAY, TREADER> {
     private TARRAY genericBlock;
     /**
      * Start of the current block. This is typically 0, but not always. If the caller does an early flush (before the
-     * block is filled), you can have multiple linked list nodes sharing different segments (slices) of the same
-     * underlying block storage.
+     * block is filled), you can end up with multiple linked list nodes sharing different segments (slices) of the same
+     * underlying array.
      */
     protected int begin;
     /**

--- a/src/main/java/io/deephaven/csv/densestorage/QueueWriter.java
+++ b/src/main/java/io/deephaven/csv/densestorage/QueueWriter.java
@@ -42,8 +42,8 @@ public class QueueWriter<TARRAY, TREADER> {
     private TARRAY genericBlock;
     /**
      * Start of the current block. This is typically 0, but not always. If the caller does an early flush (before the
-     * block is filled), you can have multiple linked list nodes sharing different segments of the same underlying block
-     * storage.
+     * block is filled), you can have multiple linked list nodes sharing different segments (slices) of the same
+     * underlying block storage.
      */
     protected int begin;
     /**
@@ -109,8 +109,8 @@ public class QueueWriter<TARRAY, TREADER> {
     private void flush(boolean isLast) {
         // Sometimes our users ask us to flush even if there is nothing to flush.
         // If the block is an "isLast" block, we need to flush it regardless of whether it contains
-        // data.
-        // Otherwise (if the block is not an "isLast" block), we only flush it if it contains data.
+        // data. Otherwise (if the block is not an "isLast" block), we only flush it if it
+        // contains data.
         if (!isLast && (current == begin)) {
             // No need to flush.
             return;
@@ -119,7 +119,7 @@ public class QueueWriter<TARRAY, TREADER> {
         // No more creating readers after the first flush.
         allowReaderCreation = false;
 
-        final QueueNode<TARRAY> newBlob = new QueueNode<>(genericBlock, begin, current, isLast);
+        final QueueNode<TARRAY> newNode = new QueueNode<>(genericBlock, begin, current, isLast);
         // If this is an early flush (before the block was filled), the next node may share
         // the same underlying storage array (but disjoint segments of that array) as the current node.
         // To accomplish this, we just advance "begin" to "current" here. At this point in the logic
@@ -128,8 +128,8 @@ public class QueueWriter<TARRAY, TREADER> {
         // calls flushAndAllocate.
         begin = current;
         synchronized (sync) {
-            tail.next = newBlob;
-            tail = newBlob;
+            tail.next = newNode;
+            tail = newNode;
             sync.notifyAll();
         }
     }

--- a/src/main/java/io/deephaven/csv/parsers/BooleanAsByteParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/BooleanAsByteParser.java
@@ -3,7 +3,7 @@ package io.deephaven.csv.parsers;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableBoolean;
+import io.deephaven.csv.util.MutableBoolean;
 import org.jetbrains.annotations.NotNull;
 
 /** The parser for the boolean (as byte) type. */

--- a/src/main/java/io/deephaven/csv/parsers/ByteParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/ByteParser.java
@@ -5,8 +5,8 @@ import io.deephaven.csv.sinks.Source;
 import io.deephaven.csv.tokenization.RangeTests;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableLong;
-import org.apache.commons.lang3.mutable.MutableObject;
+import io.deephaven.csv.util.MutableLong;
+import io.deephaven.csv.util.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 /** The parser for the byte type. */

--- a/src/main/java/io/deephaven/csv/parsers/CharParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/CharParser.java
@@ -3,7 +3,7 @@ package io.deephaven.csv.parsers;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableInt;
+import io.deephaven.csv.util.MutableInt;
 import org.jetbrains.annotations.NotNull;
 
 /** The parser for the char type. */

--- a/src/main/java/io/deephaven/csv/parsers/DateTimeAsLongParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/DateTimeAsLongParser.java
@@ -3,7 +3,7 @@ package io.deephaven.csv.parsers;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableLong;
+import io.deephaven.csv.util.MutableLong;
 import org.jetbrains.annotations.NotNull;
 
 /** The parser for the Deephaven DateTime (represented as long) type. */

--- a/src/main/java/io/deephaven/csv/parsers/DoubleParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/DoubleParser.java
@@ -3,7 +3,7 @@ package io.deephaven.csv.parsers;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableDouble;
+import io.deephaven.csv.util.MutableDouble;
 import org.jetbrains.annotations.NotNull;
 
 /** The parser for the double type. */

--- a/src/main/java/io/deephaven/csv/parsers/FloatFastParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/FloatFastParser.java
@@ -4,7 +4,7 @@ import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.tokenization.RangeTests;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableDouble;
+import io.deephaven.csv.util.MutableDouble;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/src/main/java/io/deephaven/csv/parsers/FloatStrictParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/FloatStrictParser.java
@@ -3,7 +3,7 @@ package io.deephaven.csv.parsers;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableFloat;
+import io.deephaven.csv.util.MutableFloat;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/src/main/java/io/deephaven/csv/parsers/IntParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/IntParser.java
@@ -5,8 +5,8 @@ import io.deephaven.csv.sinks.Source;
 import io.deephaven.csv.tokenization.RangeTests;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableLong;
-import org.apache.commons.lang3.mutable.MutableObject;
+import io.deephaven.csv.util.MutableLong;
+import io.deephaven.csv.util.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 /** The parser for the int type. */

--- a/src/main/java/io/deephaven/csv/parsers/LongParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/LongParser.java
@@ -4,8 +4,8 @@ import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.sinks.Source;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableLong;
-import org.apache.commons.lang3.mutable.MutableObject;
+import io.deephaven.csv.util.MutableLong;
+import io.deephaven.csv.util.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 /** The parser for the long type. */

--- a/src/main/java/io/deephaven/csv/parsers/ShortParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/ShortParser.java
@@ -5,8 +5,8 @@ import io.deephaven.csv.sinks.Source;
 import io.deephaven.csv.tokenization.RangeTests;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableLong;
-import org.apache.commons.lang3.mutable.MutableObject;
+import io.deephaven.csv.util.MutableLong;
+import io.deephaven.csv.util.MutableObject;
 import org.jetbrains.annotations.NotNull;
 
 /** The parser for the short type. */

--- a/src/main/java/io/deephaven/csv/parsers/TimestampParserBase.java
+++ b/src/main/java/io/deephaven/csv/parsers/TimestampParserBase.java
@@ -3,7 +3,7 @@ package io.deephaven.csv.parsers;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
-import org.apache.commons.lang3.mutable.MutableLong;
+import io.deephaven.csv.util.MutableLong;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/src/main/java/io/deephaven/csv/reading/CellGrabber.java
+++ b/src/main/java/io/deephaven/csv/reading/CellGrabber.java
@@ -4,9 +4,10 @@ import io.deephaven.csv.containers.ByteSlice;
 import io.deephaven.csv.containers.GrowableByteBuffer;
 import io.deephaven.csv.tokenization.RangeTests;
 import io.deephaven.csv.util.CsvReaderException;
+import io.deephaven.csv.util.MutableBoolean;
+
 import java.io.IOException;
 import java.io.InputStream;
-import org.apache.commons.lang3.mutable.MutableBoolean;
 
 /**
  * This class is used to traverse over text from a Reader, understanding both field and line delimiters, as well as the

--- a/src/main/java/io/deephaven/csv/reading/CellGrabber.java
+++ b/src/main/java/io/deephaven/csv/reading/CellGrabber.java
@@ -17,9 +17,9 @@ final class CellGrabber {
     private static final int BUFFER_SIZE = 65536;
     /** The {@link InputStream} for the input. */
     private final InputStream inputStream;
-    /** The configured CSV quote character (typically '"'). */
+    /** The configured CSV quote character (typically '"'). Must be 7-bit ASCII. */
     private final byte quoteChar;
-    /** The configured CVS field delimiter (typically ','). */
+    /** The configured CVS field delimiter (typically ','). Must be 7-bit ASCII. */
     private final byte fieldDelimiter;
     /** Whether to trim leading and trailing blanks from non-quoted values. */
     private final boolean ignoreSurroundingSpaces;

--- a/src/main/java/io/deephaven/csv/reading/CsvReader.java
+++ b/src/main/java/io/deephaven/csv/reading/CsvReader.java
@@ -9,6 +9,8 @@ import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.sinks.SinkFactory;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
+import io.deephaven.csv.util.MutableBoolean;
+import io.deephaven.csv.util.MutableObject;
 import io.deephaven.csv.util.Renderer;
 import java.io.InputStream;
 import java.io.Reader;
@@ -16,8 +18,6 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.apache.commons.lang3.mutable.MutableObject;
 
 /**
  * A class for reading CSV data. Typical usage is:

--- a/src/main/java/io/deephaven/csv/reading/CsvReader.java
+++ b/src/main/java/io/deephaven/csv/reading/CsvReader.java
@@ -1,13 +1,12 @@
 package io.deephaven.csv.reading;
 
+import io.deephaven.csv.CsvSpecs;
 import io.deephaven.csv.containers.ByteSlice;
 import io.deephaven.csv.densestorage.DenseStorageReader;
 import io.deephaven.csv.densestorage.DenseStorageWriter;
 import io.deephaven.csv.parsers.Parser;
-import io.deephaven.csv.parsers.Parsers;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.sinks.SinkFactory;
-import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
 import io.deephaven.csv.util.MutableBoolean;
 import io.deephaven.csv.util.MutableObject;
@@ -16,8 +15,6 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * A class for reading CSV data. Typical usage is:
@@ -43,82 +40,15 @@ import java.util.function.Predicate;
  * </pre>
  */
 public final class CsvReader {
-    /** Whether to trim leading and trailing blanks from non-quoted values. */
-    private boolean ignoreSurroundingSpaces = false;
-    /** Whether to trim leading and trailing blanks from inside quoted values. */
-    private boolean trim = false;
-    /** Whether the incoming data has column headers. */
-    private boolean hasHeaders = true;
     /**
-     * The quote character (used when you want field or line delimiters to be interpreted as literal text. For example:
-     *
-     * <pre>
-     * 123,"hello, there",456,
-     * </pre>
-     *
-     * Would be read as the three fields:
-     *
-     * <ul>
-     * <li>123
-     * <li>hello, there
-     * <li>456
-     * </ul>
+     * Utility class. Do not instantiate.
      */
-    private byte quoteChar = '"';
-    /** The field delimiter (the character that separates one column from the next. */
-    private byte fieldDelimiter = ',';
-    /**
-     * Whether to run concurrently. In particular, the operation of reading the raw file, breaking it into columns, and
-     * storing that column text in memory can run in parallel with parsing the data for a given column, and all the
-     * column data parsers can themselves run in parallel.
-     */
-    private boolean concurrent = true;
-    /**
-     * The user-defined set of parsers that participate in type inference. Defaults to Parsers.DEFAULT
-     */
-    private List<Parser<?>> parsers = new ArrayList<>(Parsers.DEFAULT);
-    /**
-     * Client-specified headers that can be used to override the existing headers in the input (if hasHeaders is true),
-     * or to provide absent headers (if hasHeaders is false).
-     */
-    private List<String> clientSpecifiedHeaders = new ArrayList<>();
-    /**
-     * Override a specific column header by number. This is applied *after* clientSpecifiedHeaders. Column numbers start
-     * with 1.
-     */
-    private final Map<Integer, String> columnHeaderOverrides = new HashMap<>();
-    /** Used to force a specific parser for a specific column, specified by column name. */
-    private final Map<String, Parser<?>> parsersByColumnName = new HashMap<>();
-    /**
-     * Used to force a specific parser for a specific column, specified by column number. Column numbers start with 1.
-     */
-    private final Map<Integer, Parser<?>> parsersByColumnNumber = new HashMap<>();
-    /**
-     * The default string that means "null value" in the input. It is used if not overridden on a per-column basis. It
-     * defaults to the empty string.
-     */
-    private String nullValueLiteral = "";
-    /** Used to force a specific parser for a specific column, specified by column name. */
-    private final Map<String, String> nullValueLiteralByColumnName = new HashMap<>();
-    /**
-     * Used to force a specific parser for a specific column, specified by column number. Column numbers start with 1.
-     */
-    private final Map<Integer, String> nullValueLiteralByColumnNumber = new HashMap<>();
-    /**
-     * The parser to be used when a column is entirely null (unless a specific parser has been forced by setting an
-     * entry in the parsers collection.
-     */
-    private Parser<?> nullParser;
-    /** An optional low-level parser that understands custom time zones. */
-    private Tokenizer.CustomTimeZoneParser customTimeZoneParser;
-    /** An optional validator for column headers. */
-    private Predicate<String> headerValidator = s -> true;
-    /** An optional legalizer for column headers. */
-    private Function<String[], String[]> headerLegalizer = Function.identity();
+    private CsvReader() {}
 
     /**
      * Read the data.
      *
+     * @param specs A {@link CsvSpecs} object providing options for the parse.
      * @param stream The input data, encoded in UTF-8.
      * @param sinkFactory A factory that can provide Sink&lt;T&gt; of all appropriate types for the output data. Once
      *        the CsvReader determines what the column type is, t will use the SinkFactory to create an appropriate
@@ -128,19 +58,22 @@ public final class CsvReader {
      * @return A CsvReader.Result containing the column names, the number of columns, and the final set of
      *         fully-populated Sinks.
      */
-    public Result read(final InputStream stream, final SinkFactory sinkFactory)
+    public static Result read(final CsvSpecs specs, final InputStream stream, final SinkFactory sinkFactory)
             throws CsvReaderException {
+        final byte quoteAsByte = check7BitAscii("quote", specs.quote());
+        final byte delimiterAsByte = check7BitAscii("delimiter", specs.delimiter());
         final CellGrabber grabber =
-                new CellGrabber(stream, quoteChar, fieldDelimiter, ignoreSurroundingSpaces, trim);
+                new CellGrabber(stream, quoteAsByte, delimiterAsByte, specs.ignoreSurroundingSpaces(),
+                        specs.trim());
         // For an "out" parameter
         final MutableObject<byte[][]> firstDataRowHolder = new MutableObject<>();
-        final String[] headersTemp = determineHeadersToUse(grabber, firstDataRowHolder);
+        final String[] headersTemp = determineHeadersToUse(specs, grabber, firstDataRowHolder);
         final byte[][] firstDataRow = firstDataRowHolder.getValue();
         final int numInputCols = headersTemp.length;
 
-        // If the final column has a blank header, we assume the whole column is blank (we confirm this
-        // assumption
-        // in ParseInputToDenseStorage, as we're reading the file.
+        // If the final column in the header row is blank, we assume that the final column in all the data rows
+        // is also blank (we confirm this assumption in ParseInputToDenseStorage, as we're reading the file).
+        // This corresponds to a file with trailing delimiters.
         final String[] headersTemp2;
         if (numInputCols != 0 && headersTemp[numInputCols - 1].isEmpty()) {
             headersTemp2 = Arrays.copyOf(headersTemp, numInputCols - 1);
@@ -148,7 +81,7 @@ public final class CsvReader {
             headersTemp2 = headersTemp;
         }
         final int numOutputCols = headersTemp2.length;
-        final String[] headersToUse = canonicalizeHeaders(headersTemp2);
+        final String[] headersToUse = canonicalizeHeaders(specs, headersTemp2);
 
         // Create a DenseStorageWriter and two readers for each column.
         final DenseStorageWriter[] dsws = new DenseStorageWriter[numInputCols];
@@ -156,8 +89,7 @@ public final class CsvReader {
         final DenseStorageReader[] dsr1s = new DenseStorageReader[numInputCols];
         // The arrays are sized to "numInputCols" but only populated up to "numOutputCols".
         // The code in ParseInputToDenseStorge knows that a null DenseStorageWriter means that the
-        // column
-        // is all-empty and (once the data is confirmed to be empty) just drop the data.
+        // column is all-empty and (once the data is confirmed to be empty) just drop the data.
         for (int ii = 0; ii < numOutputCols; ++ii) {
             final DenseStorageWriter dsw = new DenseStorageWriter();
             dsws[ii] = dsw;
@@ -168,7 +100,7 @@ public final class CsvReader {
         // Select an Excecutor based on whether the user wants the code to run asynchronously
         // or not.
         final ExecutorService exec =
-                concurrent
+                specs.concurrent()
                         ? Executors.newFixedThreadPool(numOutputCols + 1)
                         : Executors.newSingleThreadExecutor();
 
@@ -176,11 +108,11 @@ public final class CsvReader {
         try {
             final Future<Long> numRowsFuture =
                     exec.submit(
-                            () -> ParseInputToDenseStorage.doit(firstDataRow, nullValueLiteral, grabber, dsws));
+                            () -> ParseInputToDenseStorage.doit(firstDataRow, specs.nullValueLiteral(), grabber, dsws));
 
             for (int ii = 0; ii < numOutputCols; ++ii) {
-                final List<Parser<?>> parsersToUse = calcParsersToUse(headersToUse[ii], ii + 1);
-                final String nullValueLiteralToUse = calcNullValueLiteralToUse(headersToUse[ii], ii + 1);
+                final List<Parser<?>> parsersToUse = calcParsersToUse(specs, headersToUse[ii], ii + 1);
+                final String nullValueLiteralToUse = calcNullValueLiteralToUse(specs, headersToUse[ii], ii + 1);
 
                 final int iiCopy = ii;
                 final Future<Sink<?>> fcb =
@@ -189,8 +121,8 @@ public final class CsvReader {
                                         dsr0s[iiCopy],
                                         dsr1s[iiCopy],
                                         parsersToUse,
-                                        nullParser,
-                                        customTimeZoneParser,
+                                        specs.nullParser(),
+                                        specs.customTimeZoneParser(),
                                         nullValueLiteralToUse,
                                         sinkFactory));
                 sinkFutures.add(fcb);
@@ -216,48 +148,48 @@ public final class CsvReader {
     }
 
     /**
-     * Determine which list of parsers to use for type inference. Returns {@link #parsers} unless the user has set an
-     * override on a column name or column number basis.
+     * Determine which list of parsers to use for type inference. Returns {@link CsvSpecs#parsers} unless the user has
+     * set an override on a column name or column number basis.
      */
-    private List<Parser<?>> calcParsersToUse(
+    private static List<Parser<?>> calcParsersToUse(final CsvSpecs specs,
             final String columnName, final int oneBasedColumnNumber) {
-        Parser<?> specifiedParser = parsersByColumnName.get(columnName);
+        Parser<?> specifiedParser = specs.parserForName().get(columnName);
         if (specifiedParser != null) {
             return List.of(specifiedParser);
         }
-        specifiedParser = parsersByColumnNumber.get(oneBasedColumnNumber);
+        specifiedParser = specs.parserForIndex().get(oneBasedColumnNumber);
         if (specifiedParser != null) {
             return List.of(specifiedParser);
         }
-        return parsers;
+        return specs.parsers();
     }
 
     /**
-     * Determine which null value literal to use. Returns {@link #nullValueLiteral} unless the user has set an override
-     * on a column name or column number basis.
+     * Determine which null value literal to use. Returns {@link CsvSpecs#nullValueLiteral()} unless the user has set an
+     * override on a column name or column number basis.
      */
-    private String calcNullValueLiteralToUse(
+    private static String calcNullValueLiteralToUse(final CsvSpecs specs,
             final String columnName, final int oneBasedColumnNumber) {
-        String result = nullValueLiteralByColumnName.get(columnName);
+        String result = specs.nullValueLiteralForName().get(columnName);
         if (result != null) {
             return result;
         }
-        result = nullValueLiteralByColumnNumber.get(oneBasedColumnNumber);
+        result = specs.nullValueLiteralForIndex().get(oneBasedColumnNumber);
         if (result != null) {
             return result;
         }
-        return nullValueLiteral;
+        return specs.nullValueLiteral();
     }
 
     /**
      * Determine which headers to use. The result comes from either the first row of the file or the user-specified
      * overrides.
      */
-    private String[] determineHeadersToUse(
+    private static String[] determineHeadersToUse(final CsvSpecs specs,
             final CellGrabber grabber, final MutableObject<byte[][]> firstDataRowHolder)
             throws CsvReaderException {
         String[] headersToUse = null;
-        if (hasHeaders) {
+        if (specs.hasHeaderRow()) {
             final byte[][] firstRow = tryReadOneRow(grabber);
             if (firstRow == null) {
                 throw new CsvReaderException(
@@ -267,8 +199,8 @@ public final class CsvReader {
         }
 
         // Whether or not the input had headers, maybe override with client-specified headers.
-        if (clientSpecifiedHeaders.size() != 0) {
-            headersToUse = clientSpecifiedHeaders.toArray(new String[0]);
+        if (specs.headers().size() != 0) {
+            headersToUse = specs.headers().toArray(new String[0]);
         }
 
         // If we still have nothing, try generate synthetic column headers (works only if the file is
@@ -290,7 +222,7 @@ public final class CsvReader {
         }
 
         // Apply column specific overrides.
-        for (Map.Entry<Integer, String> entry : columnHeaderOverrides.entrySet()) {
+        for (Map.Entry<Integer, String> entry : specs.headerForIndex().entrySet()) {
             headersToUse[entry.getKey() - 1] = entry.getValue();
         }
 
@@ -298,15 +230,15 @@ public final class CsvReader {
         return headersToUse;
     }
 
-    private String[] canonicalizeHeaders(final String[] headers) throws CsvReaderException {
-        final String[] legalized = headerLegalizer.apply(headers);
+    private static String[] canonicalizeHeaders(CsvSpecs specs, final String[] headers) throws CsvReaderException {
+        final String[] legalized = specs.headerLegalizer().apply(headers);
         final Set<String> unique = new HashSet<>();
         final List<String> repeats = new ArrayList<>();
         final List<String> invalidNames = new ArrayList<>();
         for (String header : legalized) {
             if (!unique.add(header)) {
                 repeats.add(header);
-            } else if (!headerValidator.test(header)) {
+            } else if (!specs.headerValidator().test(header)) {
                 // Using an "else if" because we only want to run each unique name once through the
                 // validator.
                 invalidNames.add(header);
@@ -351,160 +283,13 @@ public final class CsvReader {
         return headers.toArray(new byte[0][]);
     }
 
-    /**
-     * Sets whether to trim leading and trailing blanks from non-quoted values. This really only matters for columns
-     * that are inferred to be of type String. Numeric columns ignore surrounding whitespace regardless of this setting.
-     */
-    public CsvReader setIgnoreSurroundingSpaces(final boolean value) {
-        ignoreSurroundingSpaces = value;
-        return this;
-    }
-
-    /**
-     * Sets whether to trim leading and trailing blanks from inside quoted values. This really only matters for columns
-     * that are inferred to be of type String. Numeric columns ignore surrounding whitespace regardless of this setting.
-     */
-    public CsvReader setTrim(final boolean value) {
-        trim = value;
-        return this;
-    }
-
-    /** Sets whether the first row of the input is column headers. */
-    public CsvReader setHasHeaders(final boolean value) {
-        hasHeaders = value;
-        return this;
-    }
-
-    /** Sets the field delimiter. Typically the comma or tab character. */
-    public CsvReader setFieldDelimiter(final char value) {
-        if (value > 0x7f) {
-            throw new IllegalArgumentException("Field delimiter needs to be a 7-bit ASCII character");
+    private static byte check7BitAscii(String what, char c) throws CsvReaderException {
+        if (c > 0x7f) {
+            final String message = String.format("%s is set to '%c' but is required to be 7-bit ASCII",
+                    what, c);
+            throw new CsvReaderException(message);
         }
-        fieldDelimiter = (byte) value;
-        return this;
-    }
-
-    /**
-     * Sets the quote character. Used by the input when it needs to escape special characters like field or line
-     * delimiters. A doubled quote character represents itself. Examples (assuming the quote character is set to '"'):
-     *
-     * <ul>
-     * <li>"Hello, there": the string Hello, there
-     * <li>"Hello""there": the string Hello"there
-     * <li>"""": the string "
-     * </ul>
-     */
-    public CsvReader setquoteChar(final char value) {
-        if (value > 0x7f) {
-            throw new IllegalArgumentException("Quote character needs to be a 7-bit ASCII character");
-        }
-        quoteChar = (byte) value;
-        return this;
-    }
-
-    /**
-     * Whether the reader should run the file tokenizer and column parsing jobs concurrently, using multiple threads.
-     * This typically yields better performance.
-     */
-    public CsvReader setConcurrent(final boolean value) {
-        this.concurrent = value;
-        return this;
-    }
-
-    /** Set the list of parsers participating in type inference. */
-    public CsvReader setParsers(final Collection<Parser<?>> parsers) {
-        this.parsers = new ArrayList<>(parsers);
-        return this;
-    }
-
-    /** Add parsers to the existing list of parsers participating in type inference. */
-    public CsvReader addParsers(Parser<?>... parsers) {
-        this.parsers.addAll(List.of(parsers));
-        return this;
-    }
-
-    /** Overrides (if hasHeaders is true) or provides (if hasHeaders is false) the column headers. */
-    public CsvReader setHeaders(final Collection<String> headers) {
-        clientSpecifiedHeaders = new ArrayList<>(headers);
-        return this;
-    }
-
-    /** Overrides (if hasHeaders is true) or provides (if hasHeaders is false) the column headers. */
-    public CsvReader setHeaders(final String... headers) {
-        clientSpecifiedHeaders = List.of(headers);
-        return this;
-    }
-
-    /** Overrides a specific column header by index. Columns are numbered starting with 1. */
-    public CsvReader setHeader(final int columnNumber, final String header) {
-        columnHeaderOverrides.put(columnNumber, header);
-        return this;
-    }
-
-    /** Specify a parser for a given column name, rather than using inference to pick a type. */
-    public CsvReader setParserFor(final String name, final Parser<?> parser) {
-        this.parsersByColumnName.put(name, parser);
-        return this;
-    }
-
-    /**
-     * Specify a parser for a given column number, rather than using inference to pick a type. The column numbers are
-     * 1-based.
-     */
-    public CsvReader setParserFor(final int columnNumber, final Parser<?> parser) {
-        this.parsersByColumnNumber.put(columnNumber, parser);
-        return this;
-    }
-
-    /** Specify the default null value literal to be used if not overridden for a column. */
-    public CsvReader setNullValueLiteral(final String nullValueLiteral) {
-        this.nullValueLiteral = nullValueLiteral;
-        return this;
-    }
-
-    /** Specify the null value literal for a given column name. */
-    public CsvReader setNullValueLiteralFor(final String name, final String nullValueLiteral) {
-        this.nullValueLiteralByColumnName.put(name, nullValueLiteral);
-        return this;
-    }
-
-    /**
-     * Specify a parser for a given column number, rather than using inference to pick a type. The column numbers are
-     * 1-based.
-     */
-    public CsvReader setNullValueLiteralFor(final int columnNumber, final String nullValueLiteral) {
-        this.nullValueLiteralByColumnNumber.put(columnNumber, nullValueLiteral);
-        return this;
-    }
-
-    /**
-     * Specify the parser to be used for columns that contain all nulls. (Unless that column has a parser specified by
-     * {@link #setParserFor}.
-     */
-    public CsvReader setNullParser(final Parser<?> nullParser) {
-        this.nullParser = nullParser;
-        return this;
-    }
-
-    /**
-     * Specify a plugin to be used to parse custom time zones. This permits the caller to support custom time zones such
-     * as the " NY" that appears in "2020-05-05 12:34:56 NY". The first digit (here, space) must be something other than
-     * "Z".
-     */
-    public CsvReader setCustomTimeZoneParser(
-            final Tokenizer.CustomTimeZoneParser customTimeZoneParser) {
-        this.customTimeZoneParser = customTimeZoneParser;
-        return this;
-    }
-
-    public CsvReader setHeaderValidator(final Predicate<String> headerValidator) {
-        this.headerValidator = headerValidator;
-        return this;
-    }
-
-    public CsvReader setHeaderLegalizer(final Function<String[], String[]> headerLegalizer) {
-        this.headerLegalizer = headerLegalizer;
-        return this;
+        return (byte) c;
     }
 
     /** Result of {@link #read}. */

--- a/src/main/java/io/deephaven/csv/reading/ParseDenseStorageToColumn.java
+++ b/src/main/java/io/deephaven/csv/reading/ParseDenseStorageToColumn.java
@@ -7,9 +7,10 @@ import io.deephaven.csv.sinks.SinkFactory;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
 import java.util.*;
-import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.apache.commons.lang3.mutable.MutableDouble;
-import org.apache.commons.lang3.mutable.MutableLong;
+
+import io.deephaven.csv.util.MutableBoolean;
+import io.deephaven.csv.util.MutableDouble;
+import io.deephaven.csv.util.MutableLong;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/src/main/java/io/deephaven/csv/reading/ParseInputToDenseStorage.java
+++ b/src/main/java/io/deephaven/csv/reading/ParseInputToDenseStorage.java
@@ -4,8 +4,9 @@ import io.deephaven.csv.containers.ByteSlice;
 import io.deephaven.csv.densestorage.DenseStorageReader;
 import io.deephaven.csv.densestorage.DenseStorageWriter;
 import io.deephaven.csv.util.CsvReaderException;
+import io.deephaven.csv.util.MutableBoolean;
+
 import java.nio.charset.StandardCharsets;
-import org.apache.commons.lang3.mutable.MutableBoolean;
 
 /**
  * The job of this class is to take the input text, parse the CSV format (dealing with quoting, escaping, field

--- a/src/main/java/io/deephaven/csv/sinks/SinkFactory.java
+++ b/src/main/java/io/deephaven/csv/sinks/SinkFactory.java
@@ -1,7 +1,8 @@
 package io.deephaven.csv.sinks;
 
+import io.deephaven.csv.util.MutableObject;
+
 import java.util.function.Supplier;
-import org.apache.commons.lang3.mutable.MutableObject;
 
 /**
  * An interface which allows the CsvReader to write to column data structures whose details it is unaware of. Using this

--- a/src/main/java/io/deephaven/csv/tokenization/Tokenizer.java
+++ b/src/main/java/io/deephaven/csv/tokenization/Tokenizer.java
@@ -2,8 +2,9 @@ package io.deephaven.csv.tokenization;
 
 import ch.randelshofer.fastdoubleparser.FastDoubleParserFromByteArray;
 import io.deephaven.csv.containers.ByteSlice;
+import io.deephaven.csv.util.*;
+
 import java.time.*;
-import org.apache.commons.lang3.mutable.*;
 
 /**
  * This class provides a variety of methods to efficiently parse various low-level types like booleans, longs, doubles,
@@ -423,7 +424,7 @@ public class Tokenizer {
                 return false;
             }
             final ZoneId zoneIdToUse = tempZoneId.getValue();
-            final long secondsOffsetToUse = temp0.getValue();
+            final long secondsOffsetToUse = temp0.longValue();
 
             final ZonedDateTime zdt =
                     ZonedDateTime.of(year, month, day, hour, minute, second, 0, zoneIdToUse);
@@ -569,7 +570,7 @@ public class Tokenizer {
             // Pad to the right with zeroes (that is, in "blah.12", the .12 is 120,000,000 nanos.
             final int length = bs.begin() - beginBeforeNs;
             for (int ii = length; ii < 9; ++ii) {
-                nanos.setValue(10 * nanos.getValue());
+                nanos.setValue(10 * nanos.longValue());
             }
             return true;
         }

--- a/src/main/java/io/deephaven/csv/util/MutableBoolean.java
+++ b/src/main/java/io/deephaven/csv/util/MutableBoolean.java
@@ -1,0 +1,16 @@
+package io.deephaven.csv.util;
+
+/**
+ * A simple wrapper class, inspired by the similar class in Apache Commons.
+ */
+public final class MutableBoolean {
+    private boolean value;
+
+    public void setValue(boolean newValue) {
+        value = newValue;
+    }
+
+    public boolean booleanValue() {
+        return value;
+    }
+}

--- a/src/main/java/io/deephaven/csv/util/MutableDouble.java
+++ b/src/main/java/io/deephaven/csv/util/MutableDouble.java
@@ -1,0 +1,16 @@
+package io.deephaven.csv.util;
+
+/**
+ * A simple wrapper class, inspired by the similar class in Apache Commons.
+ */
+public final class MutableDouble {
+    private double value;
+
+    public void setValue(double newValue) {
+        value = newValue;
+    }
+
+    public double doubleValue() {
+        return value;
+    }
+}

--- a/src/main/java/io/deephaven/csv/util/MutableFloat.java
+++ b/src/main/java/io/deephaven/csv/util/MutableFloat.java
@@ -1,0 +1,16 @@
+package io.deephaven.csv.util;
+
+/**
+ * A simple wrapper class, inspired by the similar class in Apache Commons.
+ */
+public final class MutableFloat {
+    private float value;
+
+    public void setValue(float newValue) {
+        value = newValue;
+    }
+
+    public float floatValue() {
+        return value;
+    }
+}

--- a/src/main/java/io/deephaven/csv/util/MutableInt.java
+++ b/src/main/java/io/deephaven/csv/util/MutableInt.java
@@ -1,0 +1,16 @@
+package io.deephaven.csv.util;
+
+/**
+ * A simple wrapper class, inspired by the similar class in Apache Commons.
+ */
+public final class MutableInt {
+    private int value;
+
+    public void setValue(int newValue) {
+        value = newValue;
+    }
+
+    public int intValue() {
+        return value;
+    }
+}

--- a/src/main/java/io/deephaven/csv/util/MutableLong.java
+++ b/src/main/java/io/deephaven/csv/util/MutableLong.java
@@ -1,0 +1,21 @@
+package io.deephaven.csv.util;
+
+
+/**
+ * A simple wrapper class, inspired by the similar class in Apache Commons.
+ */
+public final class MutableLong {
+    private long value;
+
+    public void setValue(long newValue) {
+        value = newValue;
+    }
+
+    public int intValue() {
+        return (int) value;
+    }
+
+    public long longValue() {
+        return value;
+    }
+}

--- a/src/main/java/io/deephaven/csv/util/MutableObject.java
+++ b/src/main/java/io/deephaven/csv/util/MutableObject.java
@@ -1,0 +1,16 @@
+package io.deephaven.csv.util;
+
+/**
+ * A simple wrapper class, inspired by the similar class in Apache Commons.
+ */
+public final class MutableObject<T> {
+    private T value;
+
+    public void setValue(T newValue) {
+        value = newValue;
+    }
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -51,7 +51,7 @@ public class CsvReaderTest {
     @Test
     public void countsAreCorrect() throws CsvReaderException {
         final String input = "" + "Values\n" + "1\n" + "\n" + "3\n";
-        final CsvReader.Result result = parse(defaultCsvReader(), toInputStream(input));
+        final CsvReader.Result result = parse(defaultCsvSpecs(), toInputStream(input));
         Assertions.assertThat(result.numCols()).isEqualTo(1);
         Assertions.assertThat(result.numRows()).isEqualTo(3);
     }
@@ -59,7 +59,7 @@ public class CsvReaderTest {
     @Test
     public void countsAreCorrectNoTrailingNewline() throws CsvReaderException {
         final String input = "" + "Values\n" + "1\n" + "\n" + "3";
-        final CsvReader.Result result = parse(defaultCsvReader(), toInputStream(input));
+        final CsvReader.Result result = parse(defaultCsvSpecs(), toInputStream(input));
         Assertions.assertThat(result.numCols()).isEqualTo(1);
         Assertions.assertThat(result.numRows()).isEqualTo(3);
     }
@@ -68,7 +68,7 @@ public class CsvReaderTest {
     public void countsAreCorrectHeaderless() throws CsvReaderException {
         final String input = "" + "1\n" + "\n" + "3\n";
         final CsvReader.Result result =
-                parse(defaultCsvReader().setHasHeaders(false).setHeaders("Value"), toInputStream(input));
+                parse(defaultCsvBuilder().hasHeaderRow(false).headers(List.of("Value")).build(), toInputStream(input));
         Assertions.assertThat(result.numCols()).isEqualTo(1);
         Assertions.assertThat(result.numRows()).isEqualTo(3);
     }
@@ -82,7 +82,7 @@ public class CsvReaderTest {
                         + "4,bar,true,2.0\n"
                         + "-5,baz,false,3.0\n";
         final CsvReader.Result result =
-                parse(defaultCsvReader().setquoteChar('|'), toInputStream(input));
+                parse(defaultCsvBuilder().quote('|').build(), toInputStream(input));
         final ColumnSet cs = toColumnSet(result);
         Assertions.assertThat(cs.columns[0].name).isEqualTo("Some\nInts");
         Assertions.assertThat(cs.columns[1].name).isEqualTo("Some\rStrings");
@@ -100,7 +100,7 @@ public class CsvReaderTest {
                         + "4,bar,true,2.0,quz\n"
                         + "-5,baz,false,3.0\n";
         Assertions.assertThatThrownBy(
-                () -> parse(defaultCsvReader().setquoteChar('|'), toInputStream(input)))
+                () -> parse(defaultCsvBuilder().quote('|').build(), toInputStream(input)))
                 .hasRootCauseMessage("Row 8 has too many columns (expected 4)");
     }
 
@@ -122,7 +122,7 @@ public class CsvReaderTest {
                                 (byte) 0)
                                 .reinterpret(boolean.class));
 
-        invokeTest(defaultCsvReader(), BOOLEAN_INPUT, expected);
+        invokeTest(defaultCsvSpecs(), BOOLEAN_INPUT, expected);
     }
 
     private static final String CHAR_INPUT =
@@ -133,7 +133,7 @@ public class CsvReaderTest {
         final ColumnSet expected =
                 ColumnSet.of(Column.ofValues("Values", 'A', Sentinels.NULL_CHAR, 'B', 'C', '1', '2', '3'));
 
-        invokeTest(defaultCsvReader(), CHAR_INPUT, expected);
+        invokeTest(defaultCsvSpecs(), CHAR_INPUT, expected);
     }
 
     @Test
@@ -143,7 +143,7 @@ public class CsvReaderTest {
         // NULL_CHAR can't be parsed as char; will be promoted to String.
         final ColumnSet expected = ColumnSet.of(Column.ofRefs("Values", "A", "" + Sentinels.NULL_CHAR));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     private static final String BYTE_INPUT = "" + "Values\n" + "-127\n" + "\n" + "127\n";
@@ -155,7 +155,7 @@ public class CsvReaderTest {
                         Column.ofValues(
                                 "Values", (byte) (Byte.MIN_VALUE + 1), Sentinels.NULL_BYTE, Byte.MAX_VALUE));
 
-        invokeTest(defaultCsvReader().setParsers(Parsers.COMPLETE), BYTE_INPUT, expected);
+        invokeTest(defaultCsvBuilder().parsers(Parsers.COMPLETE).build(), BYTE_INPUT, expected);
     }
 
     @Test
@@ -168,7 +168,7 @@ public class CsvReaderTest {
                         Column.ofValues(
                                 "Values", (short) (Byte.MIN_VALUE + 1), Sentinels.NULL_BYTE, Byte.MAX_VALUE));
 
-        invokeTest(defaultCsvReader().setParsers(Parsers.COMPLETE), input, expected);
+        invokeTest(defaultCsvBuilder().parsers(Parsers.COMPLETE).build(), input, expected);
     }
 
     @Test
@@ -179,7 +179,7 @@ public class CsvReaderTest {
                 ColumnSet.of(
                         Column.ofValues("Values", (Byte.MIN_VALUE + 1), Sentinels.NULL_INT, Byte.MAX_VALUE));
 
-        invokeTest(defaultCsvReader(), BYTE_INPUT, expected);
+        invokeTest(defaultCsvSpecs(), BYTE_INPUT, expected);
     }
 
     private static final String SHORT_INPUT = "" + "Values\n" + "-32767\n" + "\n" + "32767\n";
@@ -191,7 +191,7 @@ public class CsvReaderTest {
                         Column.ofValues(
                                 "Values", (short) (Short.MIN_VALUE + 1), Sentinels.NULL_SHORT, Short.MAX_VALUE));
 
-        invokeTest(defaultCsvReader().setParsers(Parsers.COMPLETE), SHORT_INPUT, expected);
+        invokeTest(defaultCsvBuilder().parsers(Parsers.COMPLETE).build(), SHORT_INPUT, expected);
     }
 
     @Test
@@ -204,7 +204,7 @@ public class CsvReaderTest {
                         Column.ofValues(
                                 "Values", (int) (Short.MIN_VALUE + 1), Sentinels.NULL_SHORT, Short.MAX_VALUE));
 
-        invokeTest(defaultCsvReader().setParsers(Parsers.COMPLETE), input, expected);
+        invokeTest(defaultCsvBuilder().parsers(Parsers.COMPLETE).build(), input, expected);
     }
 
     @Test
@@ -216,7 +216,7 @@ public class CsvReaderTest {
                         Column.ofValues(
                                 "Values", Integer.MIN_VALUE + 1, Sentinels.NULL_INT, Integer.MAX_VALUE));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     @Test
@@ -226,7 +226,7 @@ public class CsvReaderTest {
         // NULL_INT can't be parsed as int; will be promoted to long.
         final ColumnSet expected = ColumnSet.of(Column.ofValues("Values", (long) Sentinels.NULL_INT));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     private static final String LONG_INPUT =
@@ -238,7 +238,7 @@ public class CsvReaderTest {
                 ColumnSet.of(
                         Column.ofValues("Values", Long.MIN_VALUE + 1, Sentinels.NULL_LONG, Long.MAX_VALUE));
 
-        invokeTest(defaultCsvReader(), LONG_INPUT, expected);
+        invokeTest(defaultCsvSpecs(), LONG_INPUT, expected);
     }
 
     @Test
@@ -249,7 +249,7 @@ public class CsvReaderTest {
         final ColumnSet expected =
                 ColumnSet.of(Column.ofValues("Values", (double) Sentinels.NULL_LONG));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     @Test
@@ -257,7 +257,7 @@ public class CsvReaderTest {
         final ColumnSet expected =
                 ColumnSet.of(Column.ofRefs("Values", "-9223372036854775807", null, "9223372036854775807"));
 
-        invokeTest(defaultCsvReader().setParsers(List.of(Parsers.STRING)), LONG_INPUT, expected);
+        invokeTest(defaultCsvBuilder().parsers(List.of(Parsers.STRING)).build(), LONG_INPUT, expected);
     }
 
     @Test
@@ -265,7 +265,7 @@ public class CsvReaderTest {
         final ColumnSet expected =
                 ColumnSet.of(Column.ofRefs("Values", "-9223372036854775807", null, "9223372036854775807"));
 
-        invokeTest(defaultCsvReader().setParserFor("Values", Parsers.STRING), LONG_INPUT, expected);
+        invokeTest(defaultCsvBuilder().putParserForName("Values", Parsers.STRING).build(), LONG_INPUT, expected);
     }
 
     private static final String FLOAT_INPUT =
@@ -293,7 +293,7 @@ public class CsvReaderTest {
                                 1.17549435E-38d,
                                 1.4e-45d));
 
-        invokeTest(defaultCsvReader(), FLOAT_INPUT, expected);
+        invokeTest(defaultCsvSpecs(), FLOAT_INPUT, expected);
     }
 
     @Test
@@ -310,7 +310,7 @@ public class CsvReaderTest {
                                 Float.MIN_NORMAL,
                                 Float.MIN_VALUE));
 
-        invokeTest(defaultCsvReader().setParsers(List.of(Parsers.FLOAT_FAST)), FLOAT_INPUT, expected);
+        invokeTest(defaultCsvBuilder().parsers(List.of(Parsers.FLOAT_FAST)).build(), FLOAT_INPUT, expected);
     }
 
     @Test
@@ -324,7 +324,7 @@ public class CsvReaderTest {
         // NULL_FLOAT can't be parsed as float; will be promoted to double.
         final ColumnSet expected = ColumnSet.of(Column.ofValues("Values", nullFloatAsParsedByDouble));
 
-        invokeTest(defaultCsvReader().setParsers(Parsers.COMPLETE), input, expected);
+        invokeTest(defaultCsvBuilder().parsers(Parsers.COMPLETE).build(), input, expected);
     }
 
     @Test
@@ -352,7 +352,7 @@ public class CsvReaderTest {
                                 Double.MIN_NORMAL,
                                 Double.MIN_VALUE));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     @Test
@@ -362,7 +362,7 @@ public class CsvReaderTest {
         // NULL_DOUBLE can't be parsed as double; will be promoted to String
         final ColumnSet expected = ColumnSet.of(Column.ofRefs("Values", Sentinels.NULL_DOUBLE + ""));
 
-        invokeTest(defaultCsvReader().setParsers(Parsers.COMPLETE), input, expected);
+        invokeTest(defaultCsvBuilder().parsers(Parsers.COMPLETE).build(), input, expected);
     }
 
     @Test
@@ -399,7 +399,7 @@ public class CsvReaderTest {
                                 (short) 300,
                                 (short) 400));
 
-        invokeTest(defaultCsvReader().setParsers(Parsers.COMPLETE), input, expected);
+        invokeTest(defaultCsvBuilder().parsers(Parsers.COMPLETE).build(), input, expected);
     }
 
     @Test
@@ -415,7 +415,7 @@ public class CsvReaderTest {
         final ColumnSet expected =
                 ColumnSet.of(Column.ofRefs("Values", "Hello, world", null, "Goodbye."));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     @Test
@@ -472,8 +472,8 @@ public class CsvReaderTest {
                             SimpleInferrer.infer(expectedTypes[kk], inferredIJ, oneCharIJK);
                     final String input = "Values\n" + allInputs[ii] + allInputs[jj] + allInputs[kk];
                     final InputStream inputStream = toInputStream(input);
-                    final CsvReader csvReader = defaultCsvReader().setParsers(Parsers.COMPLETE);
-                    final ColumnSet columnSet = toColumnSet(parse(csvReader, inputStream));
+                    final CsvSpecs specs = defaultCsvBuilder().parsers(Parsers.COMPLETE).build();
+                    final ColumnSet columnSet = toColumnSet(parse(specs, inputStream));
                     final Class<?> actualType = columnSet.columns[0].reinterpretedType;
                     Assertions.assertThat(actualType)
                             .withFailMessage(
@@ -563,7 +563,7 @@ public class CsvReaderTest {
 
         final ColumnSet expected = ColumnSet.of(Column.ofRefs("Values", null, "#", "##"));
 
-        invokeTest(defaultCsvReader().setquoteChar('#'), input, expected);
+        invokeTest(defaultCsvBuilder().quote('#').build(), input, expected);
     }
 
     @Test
@@ -571,7 +571,7 @@ public class CsvReaderTest {
         final String input = "" + "Values\n" + "###\n"; // invalid
 
         Assertions.assertThatThrownBy(
-                () -> invokeTest(defaultCsvReader().setquoteChar('#'), input, ColumnSet.NONE))
+                () -> invokeTest(defaultCsvBuilder().quote('#').build(), input, ColumnSet.NONE))
                 .hasRootCauseMessage("Cell did not have closing quote character");
     }
 
@@ -580,7 +580,7 @@ public class CsvReaderTest {
         final String input = "" + "Val1,Val2\n" + "#hello#junk,there\n"; // invalid
 
         Assertions.assertThatThrownBy(
-                () -> invokeTest(defaultCsvReader().setquoteChar('#'), input, ColumnSet.NONE))
+                () -> invokeTest(defaultCsvBuilder().quote('#').build(), input, ColumnSet.NONE))
                 .hasRootCauseMessage("Logic error: final non-whitespace in field is not quoteChar");
     }
 
@@ -593,7 +593,7 @@ public class CsvReaderTest {
 
         final ColumnSet expected = ColumnSet.of(Column.ofRefs("Values", "hello", null));
 
-        invokeTest(new CsvReader().setNullValueLiteral("NULL"), input, expected);
+        invokeTest(defaultCsvBuilder().nullValueLiteral("NULL").build(), input, expected);
     }
 
     @Test
@@ -603,7 +603,7 @@ public class CsvReaderTest {
         final ColumnSet expected =
                 ColumnSet.of(Column.ofRefs("Values", "Hello, world", null, "Goodbye."));
 
-        invokeTest(defaultCsvReader().setquoteChar('#'), input, expected);
+        invokeTest(defaultCsvBuilder().quote('#').build(), input, expected);
     }
 
     @Test
@@ -615,7 +615,7 @@ public class CsvReaderTest {
                         Column.ofValues(
                                 "Values", Integer.MIN_VALUE + 1, Sentinels.NULL_INT, Integer.MAX_VALUE));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     @Test
@@ -626,7 +626,8 @@ public class CsvReaderTest {
                 ColumnSet.of(
                         Column.ofValues("A", 1, 4), Column.ofValues("Qux", 2, 5), Column.ofValues("C", 3, 6));
 
-        invokeTest(defaultCsvReader().setHeaders("A", "B", "C").setHeader(2, "Qux"), input, expected);
+        invokeTest(defaultCsvBuilder().headers(List.of("A", "B", "C")).putHeaderForIndex(2, "Qux").build(), input,
+                expected);
     }
 
     private static final String LANGUAGE_EXAMPLE_HEADERLESS_INPUT =
@@ -657,13 +658,13 @@ public class CsvReaderTest {
 
     @Test
     public void languageExample() throws CsvReaderException {
-        invokeTest(defaultCsvReader(), LANGUAGE_EXAMPLE_INPUT, languageCreatorTypeTable());
+        invokeTest(defaultCsvSpecs(), LANGUAGE_EXAMPLE_INPUT, languageCreatorTypeTable());
     }
 
     @Test
     public void languageExampleTsv() throws CsvReaderException {
         invokeTest(
-                defaultCsvReader().setFieldDelimiter('\t'),
+                defaultCsvBuilder().delimiter('\t').build(),
                 LANGUAGE_EXAMPLE_TSV,
                 languageCreatorTypeTable());
     }
@@ -671,7 +672,7 @@ public class CsvReaderTest {
     @Test
     public void languageExampleHeaderless() throws CsvReaderException {
         invokeTest(
-                defaultCsvReader().setHasHeaders(false),
+                defaultCsvBuilder().hasHeaderRow(false).build(),
                 LANGUAGE_EXAMPLE_HEADERLESS_INPUT,
                 languageCreatorTypeTableHeaderless());
     }
@@ -680,7 +681,7 @@ public class CsvReaderTest {
     public void languageExampleHeaderlessExplicit() throws CsvReaderException {
         final ColumnSet expected = languageCreatorTypeTable();
         invokeTest(
-                defaultCsvReader().setHasHeaders(false).setHeaders(List.of("Language", "Creator", "Type")),
+                defaultCsvBuilder().hasHeaderRow(false).headers(List.of("Language", "Creator", "Type")).build(),
                 LANGUAGE_EXAMPLE_HEADERLESS_INPUT,
                 expected);
     }
@@ -736,7 +737,7 @@ public class CsvReaderTest {
                         Column.ofValues("Price", 0.25, 0.15, 0.18),
                         Column.ofValues("SecurityId", 200, 300, 500));
 
-        invokeTest(defaultCsvReader(), WHITESPACE_NO_QUOTES, expected);
+        invokeTest(defaultCsvSpecs(), WHITESPACE_NO_QUOTES, expected);
     }
 
     @Test
@@ -749,7 +750,7 @@ public class CsvReaderTest {
                         Column.ofValues("SecurityId", 200, 300, 500));
 
         invokeTest(
-                defaultCsvReader().setIgnoreSurroundingSpaces(false), WHITESPACE_NO_QUOTES, expected);
+                defaultCsvBuilder().ignoreSurroundingSpaces(false).build(), WHITESPACE_NO_QUOTES, expected);
     }
 
     @Test
@@ -770,7 +771,7 @@ public class CsvReaderTest {
                         Column.ofValues("Price", 0.25, 0.15, 0.18),
                         Column.ofValues("SecurityId", 200, 300, 500));
 
-        invokeTest(defaultCsvReader().setquoteChar('|'), input, expected);
+        invokeTest(defaultCsvBuilder().quote('|').build(), input, expected);
     }
 
     // Use vertical bars instead of quotation marks to make things more readable for the humans
@@ -790,7 +791,7 @@ public class CsvReaderTest {
                         Column.ofRefs("Type", " Dividend", "Dividend ", " Dividend "),
                         Column.ofValues("Price", 0.25, 0.15, 0.18),
                         Column.ofValues("SecurityId", 200, 300, 500));
-        invokeTest(defaultCsvReader().setquoteChar('|'), WHITESPACE_INSIDE, expected);
+        invokeTest(defaultCsvBuilder().quote('|').build(), WHITESPACE_INSIDE, expected);
     }
 
     @Test
@@ -802,7 +803,7 @@ public class CsvReaderTest {
                         Column.ofValues("Price", 0.25, 0.15, 0.18),
                         Column.ofValues("SecurityId", 200, 300, 500));
 
-        invokeTest(defaultCsvReader().setquoteChar('|').setTrim(true), WHITESPACE_INSIDE, expected);
+        invokeTest(defaultCsvBuilder().quote('|').trim(true).build(), WHITESPACE_INSIDE, expected);
     }
 
     private static final String WHITESPACE_INSIDE_AND_OUTSIDE =
@@ -821,7 +822,7 @@ public class CsvReaderTest {
                         Column.ofValues("Price", 0.25, 0.15, 0.18),
                         Column.ofValues("SecurityId", 200, 300, 500));
 
-        invokeTest(defaultCsvReader().setquoteChar('|'), WHITESPACE_INSIDE_AND_OUTSIDE, expected);
+        invokeTest(defaultCsvBuilder().quote('|').build(), WHITESPACE_INSIDE_AND_OUTSIDE, expected);
     }
 
     @Test
@@ -834,7 +835,7 @@ public class CsvReaderTest {
                         Column.ofValues("SecurityId", 200, 300, 500));
 
         invokeTest(
-                defaultCsvReader().setquoteChar('|').setTrim(true),
+                defaultCsvBuilder().quote('|').trim(true).build(),
                 WHITESPACE_INSIDE_AND_OUTSIDE,
                 expected);
     }
@@ -848,7 +849,7 @@ public class CsvReaderTest {
                 ColumnSet.of(
                         Column.ofArray("Values1", new short[0]), Column.ofArray("Values2", new short[0]));
 
-        invokeTest(defaultCsvReader().setNullParser(Parsers.SHORT), input, expected);
+        invokeTest(defaultCsvBuilder().nullParser(Parsers.SHORT).build(), input, expected);
     }
 
     @Test
@@ -861,7 +862,7 @@ public class CsvReaderTest {
                         Column.ofValues("SomeInts", -3, 4, -5),
                         Column.ofRefs("SomeStrings", "foo", "bar", "baz"));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     @Test
@@ -877,7 +878,7 @@ public class CsvReaderTest {
                         Column.ofValues("D", (byte) 0, (byte) 1, Sentinels.NULL_BOOLEAN_AS_BYTE)
                                 .reinterpret(boolean.class));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     @Test
@@ -893,7 +894,7 @@ public class CsvReaderTest {
                         Column.ofValues("D", (byte) 0, (byte) 1, Sentinels.NULL_BOOLEAN_AS_BYTE)
                                 .reinterpret(boolean.class));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     @Test
@@ -901,14 +902,14 @@ public class CsvReaderTest {
         // Too many columns is an error.
         final String input = "" + "SomeInts,SomeStrings\n" + "-3,foo\n" + "4,bar,quz\n" + "-5,baz\n";
 
-        Assertions.assertThatThrownBy(() -> invokeTest(defaultCsvReader(), input, ColumnSet.NONE))
+        Assertions.assertThatThrownBy(() -> invokeTest(defaultCsvSpecs(), input, ColumnSet.NONE))
                 .hasRootCauseMessage("Row 3 has too many columns (expected 2)");
     }
 
     @Test
     public void duplicateColumnName() {
         final String input = "" + "abc,xyz,abc\n" + "Hello,there,Deephaven\n";
-        Assertions.assertThatThrownBy(() -> invokeTest(defaultCsvReader(), input, ColumnSet.NONE))
+        Assertions.assertThatThrownBy(() -> invokeTest(defaultCsvSpecs(), input, ColumnSet.NONE))
                 .hasMessageContaining("Repeated headers: abc");
     }
 
@@ -925,7 +926,7 @@ public class CsvReaderTest {
                         Column.ofRefs("def", "there", "bar"),
                         Column.ofRefs("ghi", "Deephaven", "baz"));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     @Test
@@ -935,7 +936,7 @@ public class CsvReaderTest {
         // line) will just be dropped.
         final String input =
                 "" + "abc,def,ghi,\n" + "Hello,there,Deephaven,\n" + "foo,bar,baz,nonempty\n";
-        Assertions.assertThatThrownBy(() -> invokeTest(defaultCsvReader(), input, ColumnSet.NONE))
+        Assertions.assertThatThrownBy(() -> invokeTest(defaultCsvSpecs(), input, ColumnSet.NONE))
                 .hasRootCauseMessage("Column assumed empty but contains data");
     }
 
@@ -950,7 +951,7 @@ public class CsvReaderTest {
                                 "Values", 1632769200000000000L, Sentinels.NULL_LONG, 1632772800000000000L)
                                 .reinterpret(Instant.class));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     @Test
@@ -1001,7 +1002,7 @@ public class CsvReaderTest {
                                 1632783898123456789L)
                                 .reinterpret(Instant.class));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     @Test
@@ -1017,7 +1018,7 @@ public class CsvReaderTest {
                                 1632772800000000000L)
                                 .reinterpret(Instant.class));
 
-        invokeTest(defaultCsvReader().setParsers(List.of(Parsers.TIMESTAMP_SECONDS)), input, expected);
+        invokeTest(defaultCsvBuilder().parsers(List.of(Parsers.TIMESTAMP_SECONDS)).build(), input, expected);
     }
 
     @Test
@@ -1033,7 +1034,7 @@ public class CsvReaderTest {
                                 1632772800000000000L)
                                 .reinterpret(Instant.class));
 
-        invokeTest(defaultCsvReader().setParsers(List.of(Parsers.TIMESTAMP_MILLIS)), input, expected);
+        invokeTest(defaultCsvBuilder().parsers(List.of(Parsers.TIMESTAMP_MILLIS)).build(), input, expected);
     }
 
     @Test
@@ -1049,7 +1050,7 @@ public class CsvReaderTest {
                                 1632772800000000000L)
                                 .reinterpret(Instant.class));
 
-        invokeTest(defaultCsvReader().setParsers(List.of(Parsers.TIMESTAMP_MICROS)), input, expected);
+        invokeTest(defaultCsvBuilder().parsers(List.of(Parsers.TIMESTAMP_MICROS)).build(), input, expected);
     }
 
     @Test
@@ -1065,7 +1066,7 @@ public class CsvReaderTest {
                                 1632772800000000000L)
                                 .reinterpret(Instant.class));
 
-        invokeTest(defaultCsvReader().setParsers(List.of(Parsers.TIMESTAMP_NANOS)), input, expected);
+        invokeTest(defaultCsvBuilder().parsers(List.of(Parsers.TIMESTAMP_NANOS)).build(), input, expected);
     }
 
     @Test
@@ -1097,7 +1098,7 @@ public class CsvReaderTest {
                     return false;
                 };
 
-        invokeTest(defaultCsvReader().setCustomTimeZoneParser(myTimeZoneParser), input, expected);
+        invokeTest(defaultCsvBuilder().customTimeZoneParser(myTimeZoneParser).build(), input, expected);
     }
 
     private static final String ALL_NULLS = "" + "Values\n" + "\n" + "\n" + "\n" + "\n" + "\n";
@@ -1108,7 +1109,7 @@ public class CsvReaderTest {
 
         Assertions.assertThatThrownBy(
                 () -> invokeTest(
-                        defaultCsvReader().setParsers(List.of(Parsers.INT, Parsers.LONG, Parsers.DATETIME)),
+                        defaultCsvBuilder().parsers(List.of(Parsers.INT, Parsers.LONG, Parsers.DATETIME)).build(),
                         input,
                         ColumnSet.NONE));
     }
@@ -1118,7 +1119,7 @@ public class CsvReaderTest {
         final String input = "" + "Values\n" + "hello\n" + "there\n";
 
         Assertions.assertThatThrownBy(
-                () -> invokeTest(defaultCsvReader().setParsers(List.of()), input, ColumnSet.NONE))
+                () -> invokeTest(defaultCsvBuilder().parsers(List.of()).build(), input, ColumnSet.NONE))
                 .hasRootCauseMessage("No available parsers.");
     }
 
@@ -1127,7 +1128,7 @@ public class CsvReaderTest {
         final long nv = Sentinels.NULL_LONG;
         final ColumnSet expected = ColumnSet.of(Column.ofValues("Values", nv, nv, nv, nv, nv));
 
-        invokeTest(defaultCsvReader().setParserFor("Values", Parsers.LONG), ALL_NULLS, expected);
+        invokeTest(defaultCsvBuilder().putParserForName("Values", Parsers.LONG).build(), ALL_NULLS, expected);
     }
 
     @Test
@@ -1135,12 +1136,14 @@ public class CsvReaderTest {
         final long nv = Sentinels.NULL_LONG;
         final ColumnSet expected = ColumnSet.of(Column.ofValues("Values", nv, nv, nv, nv, nv));
 
-        invokeTest(defaultCsvReader().setNullParser(Parsers.LONG), ALL_NULLS, expected);
+        invokeTest(defaultCsvBuilder().nullParser(Parsers.LONG).build(), ALL_NULLS, expected);
     }
 
     @Test
     public void allNullsButNoParser() {
-        Assertions.assertThatThrownBy(() -> invokeTest(defaultCsvReader(), ALL_NULLS, ColumnSet.NONE))
+        Assertions
+                .assertThatThrownBy(
+                        () -> invokeTest(defaultCsvBuilder().nullParser(null).build(), ALL_NULLS, ColumnSet.NONE))
                 .hasRootCauseMessage(
                         "Column contains all null cells: can't infer type of column, and nullParser is not set.");
     }
@@ -1150,7 +1153,7 @@ public class CsvReaderTest {
         final String input = "Values\n";
         final ColumnSet expected = ColumnSet.of(Column.ofArray("Values", new long[0]));
 
-        invokeTest(defaultCsvReader().setParserFor("Values", Parsers.LONG), input, expected);
+        invokeTest(defaultCsvBuilder().putParserForName("Values", Parsers.LONG).build(), input, expected);
     }
 
     @Test
@@ -1162,7 +1165,7 @@ public class CsvReaderTest {
                 ColumnSet.of(
                         Column.ofRefs("Emojis", "Hello 💖", "Regular ASCII", "✨ Deephaven ✨", "🎆🎆🎆🎆🎆"));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     /**
@@ -1178,7 +1181,7 @@ public class CsvReaderTest {
         final ColumnSet expected =
                 ColumnSet.of(Column.ofValues("BMPChar", '1', '2', '3', 'X', '✈', '❎', '➉', '✈', '✨'));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     /** Large cells (10K characters or so), some with fancy Unicode, quotes, and escaped quotes. */
@@ -1227,7 +1230,7 @@ public class CsvReaderTest {
                                 largeCellChars,
                                 largeCellLiteral));
 
-        invokeTest(defaultCsvReader(), input, expected);
+        invokeTest(defaultCsvSpecs(), input, expected);
     }
 
     /** Test the global null literal value. */
@@ -1248,7 +1251,7 @@ public class CsvReaderTest {
                         Column.ofValues("SomeLongs", 4L, Sentinels.NULL_LONG, 4000000000L));
 
         invokeTest(
-                defaultCsvReader().setParsers(Parsers.COMPLETE).setNullValueLiteral("NULL"),
+                defaultCsvBuilder().parsers(Parsers.COMPLETE).nullValueLiteral("NULL").build(),
                 input,
                 expected);
     }
@@ -1274,12 +1277,13 @@ public class CsvReaderTest {
                         Column.ofValues("SomeLongs", 4L, Sentinels.NULL_LONG, 4000000000L));
 
         invokeTest(
-                defaultCsvReader()
-                        .setParsers(Parsers.COMPLETE)
-                        .setNullValueLiteralFor(1, "❌")
-                        .setNullValueLiteralFor(2, "🔥")
-                        .setNullValueLiteralFor("SomeInts", "⋰⋱")
-                        .setNullValueLiteralFor("SomeLongs", "𝓓𝓮𝓮𝓹𝓱𝓪𝓿𝓮𝓷"),
+                defaultCsvBuilder()
+                        .parsers(Parsers.COMPLETE)
+                        .putNullValueLiteralForIndex(1, "❌")
+                        .putNullValueLiteralForIndex(2, "🔥")
+                        .putNullValueLiteralForName("SomeInts", "⋰⋱")
+                        .putNullValueLiteralForName("SomeLongs", "𝓓𝓮𝓮𝓹𝓱𝓪𝓿𝓮𝓷")
+                        .build(),
                 input,
                 expected);
     }
@@ -1347,9 +1351,10 @@ public class CsvReaderTest {
                         Column.ofArray("SomeTimestamps", timestampsAsLongs.toArray())
                                 .reinterpret(Instant.class));
         invokeTest(
-                defaultCsvReader()
-                        .setParsers(Parsers.COMPLETE)
-                        .setParserFor("SomeTimestamps", Parsers.TIMESTAMP_NANOS),
+                defaultCsvBuilder()
+                        .parsers(Parsers.COMPLETE)
+                        .putParserForName("SomeTimestamps", Parsers.TIMESTAMP_NANOS)
+                        .build(),
                 input,
                 expected);
     }
@@ -1368,7 +1373,7 @@ public class CsvReaderTest {
                         Column.ofValues("Index", 0, 1, 2),
                         Column.ofRefs("BigValues", new BigDecimal(bd1), null, new BigDecimal(bd2)));
 
-        invokeTest(defaultCsvReader().setParserFor(2, new MyBigDecimalParser()), input, expected);
+        invokeTest(defaultCsvBuilder().putParserForIndex(2, new MyBigDecimalParser()).build(), input, expected);
     }
 
     private static class MyBigDecimalParser implements Parser<BigDecimal[]> {
@@ -1612,14 +1617,18 @@ public class CsvReaderTest {
         }
     }
 
-    private static CsvReader defaultCsvReader() {
-        return new CsvReader().setIgnoreSurroundingSpaces(true);
+    private static CsvSpecs defaultCsvSpecs() {
+        return defaultCsvBuilder().build();
     }
 
-    private static void invokeTest(CsvReader csvReader, String input, ColumnSet expected)
+    private static CsvSpecs.Builder defaultCsvBuilder() {
+        return CsvSpecs.builder().ignoreSurroundingSpaces(true);
+    }
+
+    private static void invokeTest(final CsvSpecs specs, final String input, final ColumnSet expected)
             throws CsvReaderException {
         final InputStream inputStream = toInputStream(input);
-        final CsvReader.Result result = parse(csvReader, inputStream);
+        final CsvReader.Result result = parse(specs, inputStream);
         final ColumnSet actual = toColumnSet(result);
         final String expectedToString = expected.toString();
         final String actualToString = actual.toString();
@@ -1633,9 +1642,9 @@ public class CsvReaderTest {
      * @return The parsed data
      * @throws CsvReaderException If any sort of failure occurs.
      */
-    private static CsvReader.Result parse(CsvReader csvReader, InputStream inputStream)
+    private static CsvReader.Result parse(final CsvSpecs specs, final InputStream inputStream)
             throws CsvReaderException {
-        return csvReader.read(inputStream, makeMySinkFactory());
+        return CsvReader.read(specs, inputStream, makeMySinkFactory());
     }
 
     /** Convert String to InputStream */


### PR DESCRIPTION
This PR is divided into five separate commits. These commits are:

1. Clean up some comments
- self-explanatory
2. Remove reference to Apache Commons, do our own simple MutableT implementations.
- self-explantory
3. Upon normal or abnormal exit, clean up threads.
- The purpose here is to do a proper shutdown both at normal termination and at abnormal termination, interrupting the worker threads if necessary
4. Rather than having a hand-written builder, use Java "Immutables" style.
- There's a little explanation in order here:
- Previously on the CsvReader library side, we did our own configuration options, with hand-written setters; and then on the Deephaven side we had two classes CsvSpecs and InferenceSpecs, and we had some glue code which copied the fields from CsvSpecs and InferenceSpecs over to CsvReader
- In this library, we adopt CsvSpecs, we ABSORB InferenceSpecs into CsvSpecs (so there is only one Specs class rather than nested Specs classes, which was IMO annoying) and CsvReader is now a static utility class (e.g. no hand-written setters)
5. Update the JMH code to reflect the above "Immutables" change.