### PR TITLE
Modify CSV parser library so it doesn't have a dependency on FastDoubleParser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 group = 'io.deephaven'
-version = '0.2.0-SNAPSHOT'
+version = '0.3.0-SNAPSHOT'
 
 description = 'The Deephaven High-Performance CSV Parser'
 
@@ -34,12 +34,12 @@ configurations {
 }
 
 dependencies {
-    implementation 'ch.randelshofer:fastdoubleparser:0.3.0'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 
     annotationProcessor 'org.immutables:value:2.9.0'
     compileOnly 'org.immutables:value-annotations:2.9.0'
 
+    testImplementation 'ch.randelshofer:fastdoubleparser:0.3.0'
     testImplementation 'net.sf.trove4j:trove4j:3.0.3'
     testImplementation 'commons-io:commons-io:2.11.0'
     testCompileOnly 'org.jetbrains:annotations:23.0.0'

--- a/src/jmh/java/io/deephaven/csv/benchmark/doublecol/DoubleColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/doublecol/DoubleColumnParserDeephaven.java
@@ -1,5 +1,6 @@
 package io.deephaven.csv.benchmark.doublecol;
 
+import ch.randelshofer.fastdoubleparser.FastDoubleParserFromByteArray;
 import io.deephaven.csv.CsvSpecs;
 import io.deephaven.csv.benchmark.util.ArrayBacked;
 import io.deephaven.csv.benchmark.util.BenchmarkResult;
@@ -17,6 +18,7 @@ public final class DoubleColumnParserDeephaven {
         final SinkFactory sinkFactory = SinkFactories.makeRecyclingSinkFactory(null, null, null, storage, null, null);
         final CsvSpecs specs = CsvSpecs.builder()
                 .parsers(List.of(Parsers.DOUBLE))
+                .customDoubleParser(FastDoubleParserFromByteArray::parseDouble)
                 .hasHeaderRow(true)
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);

--- a/src/jmh/java/io/deephaven/csv/benchmark/largenumericonly/LargeNumericOnlyDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/largenumericonly/LargeNumericOnlyDeephaven.java
@@ -1,5 +1,6 @@
 package io.deephaven.csv.benchmark.largenumericonly;
 
+import ch.randelshofer.fastdoubleparser.FastDoubleParserFromByteArray;
 import io.deephaven.csv.CsvSpecs;
 import io.deephaven.csv.benchmark.util.ArrayBacked;
 import io.deephaven.csv.benchmark.util.SinkFactories;
@@ -22,6 +23,7 @@ public class LargeNumericOnlyDeephaven {
 
         final CsvSpecs specs = CsvSpecs.builder()
                 .hasHeaderRow(true)
+                .customDoubleParser(FastDoubleParserFromByteArray::parseDouble)
                 .putParserForIndex(1, Parsers.LONG)
                 .putParserForIndex(2, Parsers.LONG)
                 .putParserForIndex(3, Parsers.LONG)

--- a/src/jmh/java/io/deephaven/csv/benchmark/largetable/LargeTableDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/largetable/LargeTableDeephaven.java
@@ -1,5 +1,6 @@
 package io.deephaven.csv.benchmark.largetable;
 
+import ch.randelshofer.fastdoubleparser.FastDoubleParserFromByteArray;
 import io.deephaven.csv.CsvSpecs;
 import io.deephaven.csv.benchmark.util.ArrayBacked;
 import io.deephaven.csv.benchmark.util.SinkFactories;
@@ -21,6 +22,7 @@ public class LargeTableDeephaven {
                 new long[][] {results.timestamps});
         final CsvSpecs specs = CsvSpecs.builder()
                 .hasHeaderRow(true)
+                .customDoubleParser(FastDoubleParserFromByteArray::parseDouble)
                 .putParserForIndex(1, Parsers.DATETIME)
                 .putParserForIndex(2, Parsers.STRING)
                 .putParserForIndex(3, Parsers.BOOLEAN)

--- a/src/jmh/java/io/deephaven/csv/benchmark/util/DateTimeToLongParser.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/util/DateTimeToLongParser.java
@@ -35,7 +35,7 @@ public interface DateTimeToLongParser {
         private byte[] bytes = new byte[0];
 
         public Deephaven() {
-            this(new Tokenizer(null));
+            this(new Tokenizer(null, null));
         }
 
         public Deephaven(Tokenizer tokenizer) {

--- a/src/main/java/io/deephaven/csv/CsvSpecs.java
+++ b/src/main/java/io/deephaven/csv/CsvSpecs.java
@@ -18,7 +18,6 @@ import java.util.function.Predicate;
 @Immutable
 @BuildableStyle
 public abstract class CsvSpecs {
-
     public interface Builder {
         /**
          * Copy all of the parameters from {@code specs} into {@code this} builder.
@@ -88,7 +87,15 @@ public abstract class CsvSpecs {
         Builder nullParser(Parser<?> parser);
 
         /**
-         * An optional low-level parser that understands custom time zones.
+         * An optional (but strongly encouraged) double parser, such as
+         * https://github.com/wrandelshofer/FastDoubleParser that will improve the performance of double parsing.
+         */
+        Builder customDoubleParser(Tokenizer.CustomDoubleParser customDoubleParser);
+
+        /**
+         * An optional low-level "timezone parser" that understands custom time zone strings. For example the Deephaven
+         * system allows special timezones like " NY" and " MN" as in "2020-03-01T12:34:56 NY" (note also the explicit
+         * space). The timezone parser must be reentrant.
          */
         Builder customTimeZoneParser(Tokenizer.CustomTimeZoneParser customTimeZoneParser);
 
@@ -235,6 +242,15 @@ public abstract class CsvSpecs {
     @Nullable
     public Parser<?> nullParser() {
         return Parsers.STRING;
+    }
+
+    /**
+     * See {@link Builder#customDoubleParser}.
+     */
+    @Default
+    @Nullable
+    public Tokenizer.CustomDoubleParser customDoubleParser() {
+        return null;
     }
 
     /**

--- a/src/main/java/io/deephaven/csv/reading/CsvReader.java
+++ b/src/main/java/io/deephaven/csv/reading/CsvReader.java
@@ -123,6 +123,7 @@ public final class CsvReader {
                                         dsr1s[iiCopy],
                                         parsersToUse,
                                         specs.nullParser(),
+                                        specs.customDoubleParser(),
                                         specs.customTimeZoneParser(),
                                         nullValueLiteralToUse,
                                         sinkFactory));

--- a/src/main/java/io/deephaven/csv/reading/ParseDenseStorageToColumn.java
+++ b/src/main/java/io/deephaven/csv/reading/ParseDenseStorageToColumn.java
@@ -23,11 +23,16 @@ public final class ParseDenseStorageToColumn {
      * @param dsrAlt A second reader for the same input (used to perform the second pass over the data, if type
      *        inference deems a second pass to be necessary).
      * @param parsers The set of parsers to try. If null, then {@link Parsers#DEFAULT} will be used.
-     * @param nullValueLiteral If a cell text is equal to this value, it will be interpreted as the null value.
-     *        Typically set to the empty string.
      * @param nullParser The Parser to use if {@code parsers.size() > 1} but the column contains all null values. This
      *        is needed as a backstop because otherwise type inference would have no way to choose among the multiple
      *        parsers.
+     * @param customDoubleParser An optional (but encouraged) callback for parsing doubles faster than Java's builtin
+     *        {@link Double#parseDouble}. One such library is https://github.com/wrandelshofer/FastDoubleParser
+     * @param customTimeZoneParser An optional time zone parser, if your implementation has special time zone names. For
+     *        example Deephaven supports timezones like " NY" and " MN" as in "2020-03-01T12:34:56 NY" (including the
+     *        space).
+     * @param nullValueLiteral If a cell text is equal to this value, it will be interpreted as the null value.
+     *        Typically set to the empty string.
      * @param sinkFactory Factory that makes all of the Sinks of various types, used to consume the data we produce.
      * @return The {@link Sink}, provided by the caller's {@link SinkFactory}, that was selected to hold the column
      *         data.
@@ -37,13 +42,14 @@ public final class ParseDenseStorageToColumn {
             final DenseStorageReader dsrAlt,
             List<Parser<?>> parsers,
             final Parser<?> nullParser,
+            final Tokenizer.CustomDoubleParser customDoubleParser,
             final Tokenizer.CustomTimeZoneParser customTimeZoneParser,
             final String nullValueLiteral,
             final SinkFactory sinkFactory)
             throws CsvReaderException {
         Set<Parser<?>> parserSet = new HashSet<>(Objects.requireNonNullElse(parsers, Parsers.DEFAULT));
 
-        final Tokenizer tokenizer = new Tokenizer(customTimeZoneParser);
+        final Tokenizer tokenizer = new Tokenizer(customDoubleParser, customTimeZoneParser);
         final Parser.GlobalContext gctx =
                 new Parser.GlobalContext(tokenizer, sinkFactory, nullValueLiteral);
 


### PR DESCRIPTION
...instead, the user is expected to install a FastDoubleParser as a callback