### PR TITLE
A variety of changes to make the library more friendly to the new user.

### DIFF
--- a/src/jmh/java/io/deephaven/csv/benchmark/datetimecol/DateTimeColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/datetimecol/DateTimeColumnParserDeephaven.java
@@ -1,7 +1,6 @@
 package io.deephaven.csv.benchmark.datetimecol;
 
 import io.deephaven.csv.CsvSpecs;
-import io.deephaven.csv.benchmark.util.ArrayBacked;
 import io.deephaven.csv.benchmark.util.BenchmarkResult;
 import io.deephaven.csv.benchmark.util.SinkFactories;
 import io.deephaven.csv.parsers.Parsers;
@@ -21,7 +20,7 @@ public final class DateTimeColumnParserDeephaven {
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final long[][] data = Arrays.stream(result.columns())
-                .map(col -> ((ArrayBacked<long[]>) col).getUnderlyingArray()).toArray(long[][]::new);
+                .map(col -> ((long[]) col)).toArray(long[][]::new);
         return BenchmarkResult.of(result.numRows(), data);
     }
 }

--- a/src/jmh/java/io/deephaven/csv/benchmark/datetimecol/DateTimeColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/datetimecol/DateTimeColumnParserDeephaven.java
@@ -20,7 +20,7 @@ public final class DateTimeColumnParserDeephaven {
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final long[][] data = Arrays.stream(result.columns())
-                .map(col -> ((long[]) col)).toArray(long[][]::new);
+                .map(col -> ((long[]) col.data())).toArray(long[][]::new);
         return BenchmarkResult.of(result.numRows(), data);
     }
 }

--- a/src/jmh/java/io/deephaven/csv/benchmark/doublecol/DoubleColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/doublecol/DoubleColumnParserDeephaven.java
@@ -20,7 +20,7 @@ public final class DoubleColumnParserDeephaven {
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final double[][] data = Arrays.stream(result.columns())
-                .map(col -> ((double[]) col)).toArray(double[][]::new);
+                .map(col -> ((double[]) col.data())).toArray(double[][]::new);
         return BenchmarkResult.of(result.numRows(), data);
     }
 }

--- a/src/jmh/java/io/deephaven/csv/benchmark/doublecol/DoubleColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/doublecol/DoubleColumnParserDeephaven.java
@@ -1,7 +1,6 @@
 package io.deephaven.csv.benchmark.doublecol;
 
 import io.deephaven.csv.CsvSpecs;
-import io.deephaven.csv.benchmark.util.ArrayBacked;
 import io.deephaven.csv.benchmark.util.BenchmarkResult;
 import io.deephaven.csv.benchmark.util.SinkFactories;
 import io.deephaven.csv.parsers.Parsers;
@@ -21,7 +20,7 @@ public final class DoubleColumnParserDeephaven {
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final double[][] data = Arrays.stream(result.columns())
-                .map(col -> ((ArrayBacked<double[]>) col).getUnderlyingArray()).toArray(double[][]::new);
+                .map(col -> ((double[]) col)).toArray(double[][]::new);
         return BenchmarkResult.of(result.numRows(), data);
     }
 }

--- a/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnParserDeephaven.java
@@ -1,7 +1,6 @@
 package io.deephaven.csv.benchmark.intcol;
 
 import io.deephaven.csv.CsvSpecs;
-import io.deephaven.csv.benchmark.util.ArrayBacked;
 import io.deephaven.csv.benchmark.util.BenchmarkResult;
 import io.deephaven.csv.benchmark.util.SinkFactories;
 import io.deephaven.csv.parsers.Parsers;
@@ -21,7 +20,7 @@ public final class IntColumnParserDeephaven {
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final int[][] data = Arrays.stream(result.columns())
-                .map(col -> ((ArrayBacked<int[]>) col).getUnderlyingArray()).toArray(int[][]::new);
+                .map(col -> ((int[]) col)).toArray(int[][]::new);
         return BenchmarkResult.of(result.numRows(), data);
     }
 }

--- a/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnParserDeephaven.java
@@ -20,7 +20,7 @@ public final class IntColumnParserDeephaven {
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final int[][] data = Arrays.stream(result.columns())
-                .map(col -> ((int[]) col)).toArray(int[][]::new);
+                .map(col -> ((int[]) col.data())).toArray(int[][]::new);
         return BenchmarkResult.of(result.numRows(), data);
     }
 }

--- a/src/jmh/java/io/deephaven/csv/benchmark/largenumericonly/LargeNumericOnlyDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/largenumericonly/LargeNumericOnlyDeephaven.java
@@ -1,7 +1,6 @@
 package io.deephaven.csv.benchmark.largenumericonly;
 
 import io.deephaven.csv.CsvSpecs;
-import io.deephaven.csv.benchmark.util.ArrayBacked;
 import io.deephaven.csv.benchmark.util.SinkFactories;
 import io.deephaven.csv.parsers.Parsers;
 import io.deephaven.csv.reading.CsvReader;
@@ -32,15 +31,15 @@ public class LargeNumericOnlyDeephaven {
                 .putParserForIndex(8, Parsers.DOUBLE)
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
-        final Sink<?>[] sinks = result.columns();
+        final Object[] sinks = result.columns();
         return new Results(
-                ((ArrayBacked<long[]>) sinks[0]).getUnderlyingArray(),
-                ((ArrayBacked<long[]>) sinks[1]).getUnderlyingArray(),
-                ((ArrayBacked<long[]>) sinks[2]).getUnderlyingArray(),
-                ((ArrayBacked<long[]>) sinks[3]).getUnderlyingArray(),
-                ((ArrayBacked<double[]>) sinks[4]).getUnderlyingArray(),
-                ((ArrayBacked<double[]>) sinks[5]).getUnderlyingArray(),
-                ((ArrayBacked<double[]>) sinks[6]).getUnderlyingArray(),
-                ((ArrayBacked<double[]>) sinks[7]).getUnderlyingArray());
+                (long[]) sinks[0],
+                (long[]) sinks[1],
+                (long[]) sinks[2],
+                (long[]) sinks[3],
+                (double[]) sinks[4],
+                (double[]) sinks[5],
+                (double[]) sinks[6],
+                (double[]) sinks[7]);
     }
 }

--- a/src/jmh/java/io/deephaven/csv/benchmark/largetable/LargeTableDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/largetable/LargeTableDeephaven.java
@@ -1,7 +1,6 @@
 package io.deephaven.csv.benchmark.largetable;
 
 import io.deephaven.csv.CsvSpecs;
-import io.deephaven.csv.benchmark.util.ArrayBacked;
 import io.deephaven.csv.benchmark.util.SinkFactories;
 import io.deephaven.csv.parsers.Parsers;
 import io.deephaven.csv.reading.CsvReader;
@@ -31,15 +30,15 @@ public class LargeTableDeephaven {
                 .putParserForIndex(8, Parsers.DOUBLE)
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
-        final Sink<?>[] sinks = result.columns();
+        final Object[] sinks = result.columns();
         return new Results(
-                ((ArrayBacked<long[]>) sinks[0]).getUnderlyingArray(),
-                ((ArrayBacked<String[]>) sinks[1]).getUnderlyingArray(),
-                ((ArrayBacked<byte[]>) sinks[2]).getUnderlyingArray(),
-                ((ArrayBacked<long[]>) sinks[3]).getUnderlyingArray(),
-                ((ArrayBacked<long[]>) sinks[4]).getUnderlyingArray(),
-                ((ArrayBacked<double[]>) sinks[5]).getUnderlyingArray(),
-                ((ArrayBacked<double[]>) sinks[6]).getUnderlyingArray(),
-                ((ArrayBacked<double[]>) sinks[7]).getUnderlyingArray());
+                (long[]) sinks[0],
+                (String[]) sinks[1],
+                (byte[]) sinks[2],
+                (long[]) sinks[3],
+                (long[]) sinks[4],
+                (double[]) sinks[5],
+                (double[]) sinks[6],
+                (double[]) sinks[7]);
     }
 }

--- a/src/jmh/java/io/deephaven/csv/benchmark/stringcol/StringColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/stringcol/StringColumnParserDeephaven.java
@@ -20,7 +20,7 @@ public final class StringColumnParserDeephaven {
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final String[][] data = Arrays.stream(result.columns())
-                .map(col -> ((String[]) col)).toArray(String[][]::new);
+                .map(col -> ((String[]) col.data())).toArray(String[][]::new);
         return BenchmarkResult.of(result.numRows(), data);
     }
 }

--- a/src/jmh/java/io/deephaven/csv/benchmark/stringcol/StringColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/stringcol/StringColumnParserDeephaven.java
@@ -1,7 +1,6 @@
 package io.deephaven.csv.benchmark.stringcol;
 
 import io.deephaven.csv.CsvSpecs;
-import io.deephaven.csv.benchmark.util.ArrayBacked;
 import io.deephaven.csv.benchmark.util.BenchmarkResult;
 import io.deephaven.csv.benchmark.util.SinkFactories;
 import io.deephaven.csv.parsers.Parsers;
@@ -11,7 +10,6 @@ import io.deephaven.csv.sinks.SinkFactory;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 public final class StringColumnParserDeephaven {
     public static BenchmarkResult<String[]> read(final InputStream in, final String[][] storage) throws Exception {
@@ -22,7 +20,7 @@ public final class StringColumnParserDeephaven {
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final String[][] data = Arrays.stream(result.columns())
-                .map(col -> ((ArrayBacked<String[]>) col).getUnderlyingArray()).toArray(String[][]::new);
+                .map(col -> ((String[]) col)).toArray(String[][]::new);
         return BenchmarkResult.of(result.numRows(), data);
     }
 }

--- a/src/jmh/java/io/deephaven/csv/benchmark/util/ArrayBacked.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/util/ArrayBacked.java
@@ -1,5 +1,0 @@
-package io.deephaven.csv.benchmark.util;
-
-public interface ArrayBacked<TARRAY> {
-    TARRAY getUnderlyingArray();
-}

--- a/src/jmh/java/io/deephaven/csv/benchmark/util/SinkFactories.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/util/SinkFactories.java
@@ -49,7 +49,7 @@ public final class SinkFactories {
         }
     }
 
-    private static final class ArrayBackedSourceSink<TARRAY> implements SourceSink<TARRAY>, ArrayBacked<TARRAY> {
+    private static final class ArrayBackedSourceSink<TARRAY> implements SourceSink<TARRAY> {
         public static <TARRAY> ArrayBackedSourceSink<TARRAY> of(final TARRAY storage) {
             return new ArrayBackedSourceSink<>(storage);
         }
@@ -74,7 +74,7 @@ public final class SinkFactories {
         }
 
         @Override
-        public TARRAY getUnderlyingArray() {
+        public Object getUnderlying() {
             return storage;
         }
     }

--- a/src/main/java/io/deephaven/csv/CsvSpecs.java
+++ b/src/main/java/io/deephaven/csv/CsvSpecs.java
@@ -116,7 +116,7 @@ public abstract class CsvSpecs {
         Builder headerValidator(Predicate<String> headerValidator);
 
         /**
-         * An optional low-level parser that understands custom time zones.
+         * Whether the input file has a header row.
          */
         Builder hasHeaderRow(boolean hasHeaderRow);
 

--- a/src/main/java/io/deephaven/csv/CsvSpecs.java
+++ b/src/main/java/io/deephaven/csv/CsvSpecs.java
@@ -6,7 +6,6 @@ import io.deephaven.csv.parsers.Parsers;
 import io.deephaven.csv.tokenization.JdkDoubleParser;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.tokenization.Tokenizer.CustomDoubleParser;
-import io.deephaven.csv.tokenization.Tokenizer.CustomTimeZoneParser;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 import org.jetbrains.annotations.Nullable;
@@ -116,7 +115,7 @@ public abstract class CsvSpecs {
         Builder headerValidator(Predicate<String> headerValidator);
 
         /**
-         * Whether the input file has a header row.
+         * Whether the input file has a header row. Defaults to true.
          */
         Builder hasHeaderRow(boolean hasHeaderRow);
 

--- a/src/main/java/io/deephaven/csv/parsers/BooleanAsByteParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/BooleanAsByteParser.java
@@ -1,5 +1,6 @@
 package io.deephaven.csv.parsers;
 
+import io.deephaven.csv.reading.CsvReader;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
@@ -16,7 +17,7 @@ public final class BooleanAsByteParser implements Parser<byte[]> {
     @Override
     public ParserContext<byte[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final Sink<byte[]> sink = gctx.sinkFactory.forBooleanAsByte();
-        return new ParserContext<>(sink, null, new byte[chunkSize]);
+        return new ParserContext<>(sink, null, DataType.BOOLEAN_AS_BYTE, new byte[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/parsers/ByteParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/ByteParser.java
@@ -20,7 +20,7 @@ public final class ByteParser implements Parser<byte[]> {
     public ParserContext<byte[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<byte[]>> sourceHolder = new MutableObject<>();
         final Sink<byte[]> sink = gctx.sinkFactory.forByte(sourceHolder);
-        return new ParserContext<>(sink, sourceHolder.getValue(), new byte[chunkSize]);
+        return new ParserContext<>(sink, sourceHolder.getValue(), DataType.BYTE, new byte[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/parsers/CharParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/CharParser.java
@@ -16,7 +16,7 @@ public final class CharParser implements Parser<char[]> {
     @Override
     public ParserContext<char[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final Sink<char[]> sink = gctx.sinkFactory.forChar();
-        return new ParserContext<>(sink, null, new char[chunkSize]);
+        return new ParserContext<>(sink, null, DataType.CHAR, new char[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/parsers/DataType.java
+++ b/src/main/java/io/deephaven/csv/parsers/DataType.java
@@ -1,0 +1,5 @@
+package io.deephaven.csv.parsers;
+
+public enum DataType {
+    BOOLEAN_AS_BYTE, BYTE, SHORT, INT, LONG, FLOAT, DOUBLE, DATETIME_AS_LONG, CHAR, STRING, TIMESTAMP_AS_LONG, CUSTOM
+}

--- a/src/main/java/io/deephaven/csv/parsers/DateTimeAsLongParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/DateTimeAsLongParser.java
@@ -16,7 +16,7 @@ public final class DateTimeAsLongParser implements Parser<long[]> {
     @Override
     public ParserContext<long[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final Sink<long[]> sink = gctx.sinkFactory.forDateTimeAsLong();
-        return new ParserContext<>(sink, null, new long[chunkSize]);
+        return new ParserContext<>(sink, null, DataType.DATETIME_AS_LONG, new long[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/parsers/DoubleParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/DoubleParser.java
@@ -16,7 +16,7 @@ public final class DoubleParser implements Parser<double[]> {
     @Override
     public ParserContext<double[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final Sink<double[]> sink = gctx.sinkFactory.forDouble();
-        return new ParserContext<>(sink, null, new double[chunkSize]);
+        return new ParserContext<>(sink, null, DataType.DOUBLE, new double[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/parsers/FloatFastParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/FloatFastParser.java
@@ -23,7 +23,7 @@ public final class FloatFastParser implements Parser<float[]> {
     @Override
     public ParserContext<float[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final Sink<float[]> sink = gctx.sinkFactory.forFloat();
-        return new ParserContext<>(sink, null, new float[chunkSize]);
+        return new ParserContext<>(sink, null, DataType.FLOAT, new float[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/parsers/FloatStrictParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/FloatStrictParser.java
@@ -21,7 +21,7 @@ public final class FloatStrictParser implements Parser<float[]> {
     @Override
     public ParserContext<float[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final Sink<float[]> sink = gctx.sinkFactory.forFloat();
-        return new ParserContext<>(sink, null, new float[chunkSize]);
+        return new ParserContext<>(sink, null, DataType.FLOAT, new float[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/parsers/IntParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/IntParser.java
@@ -20,7 +20,7 @@ public final class IntParser implements Parser<int[]> {
     public ParserContext<int[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<int[]>> sourceHolder = new MutableObject<>();
         final Sink<int[]> sink = gctx.sinkFactory.forInt(sourceHolder);
-        return new ParserContext<>(sink, sourceHolder.getValue(), new int[chunkSize]);
+        return new ParserContext<>(sink, sourceHolder.getValue(), DataType.INT, new int[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/parsers/LongParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/LongParser.java
@@ -19,7 +19,7 @@ public final class LongParser implements Parser<long[]> {
     public ParserContext<long[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<long[]>> sourceHolder = new MutableObject<>();
         final Sink<long[]> sink = gctx.sinkFactory.forLong(sourceHolder);
-        return new ParserContext<>(sink, sourceHolder.getValue(), new long[chunkSize]);
+        return new ParserContext<>(sink, sourceHolder.getValue(), DataType.LONG, new long[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/parsers/Parser.java
+++ b/src/main/java/io/deephaven/csv/parsers/Parser.java
@@ -1,5 +1,6 @@
 package io.deephaven.csv.parsers;
 
+import io.deephaven.csv.reading.CsvReader;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.sinks.SinkFactory;
 import io.deephaven.csv.sinks.Source;
@@ -149,11 +150,14 @@ public interface Parser<TARRAY> {
     class ParserContext<TARRAY> {
         private final Sink<TARRAY> sink;
         private final Source<TARRAY> source;
+        private final DataType dataType;
         private final TARRAY valueChunk;
 
-        public ParserContext(Sink<TARRAY> sink, Source<TARRAY> source, TARRAY valueChunk) {
+        public ParserContext(final Sink<TARRAY> sink, final Source<TARRAY> source,
+                final DataType dataType, final TARRAY valueChunk) {
             this.sink = sink;
             this.source = source;
+            this.dataType = dataType;
             this.valueChunk = valueChunk;
         }
 
@@ -163,6 +167,10 @@ public interface Parser<TARRAY> {
 
         public Source<TARRAY> source() {
             return source;
+        }
+
+        public DataType dataType() {
+            return dataType;
         }
 
         public TARRAY valueChunk() {

--- a/src/main/java/io/deephaven/csv/parsers/Parser.java
+++ b/src/main/java/io/deephaven/csv/parsers/Parser.java
@@ -1,13 +1,11 @@
 package io.deephaven.csv.parsers;
 
-import io.deephaven.csv.reading.CsvReader;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.sinks.SinkFactory;
 import io.deephaven.csv.sinks.Source;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/io/deephaven/csv/parsers/ShortParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/ShortParser.java
@@ -20,7 +20,7 @@ public final class ShortParser implements Parser<short[]> {
     public ParserContext<short[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<short[]>> sourceHolder = new MutableObject<>();
         final Sink<short[]> sink = gctx.sinkFactory.forShort(sourceHolder);
-        return new ParserContext<>(sink, sourceHolder.getValue(), new short[chunkSize]);
+        return new ParserContext<>(sink, sourceHolder.getValue(), DataType.SHORT, new short[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/parsers/StringParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/StringParser.java
@@ -14,7 +14,7 @@ public final class StringParser implements Parser<String[]> {
     @Override
     public ParserContext<String[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final Sink<String[]> sink = gctx.sinkFactory.forString();
-        return new ParserContext<>(sink, null, new String[chunkSize]);
+        return new ParserContext<>(sink, null, DataType.STRING, new String[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/parsers/TimestampParserBase.java
+++ b/src/main/java/io/deephaven/csv/parsers/TimestampParserBase.java
@@ -32,7 +32,7 @@ public abstract class TimestampParserBase implements Parser<long[]> {
     public ParserContext<long[]> makeParserContext(
             final Parser.GlobalContext gctx, final int chunkSize) {
         final Sink<long[]> sink = gctx.sinkFactory.forTimestampAsLong();
-        return new ParserContext<>(sink, null, new long[chunkSize]);
+        return new ParserContext<>(sink, null, DataType.TIMESTAMP_AS_LONG, new long[chunkSize]);
     }
 
     @Override

--- a/src/main/java/io/deephaven/csv/reading/CsvReader.java
+++ b/src/main/java/io/deephaven/csv/reading/CsvReader.java
@@ -352,8 +352,8 @@ public final class CsvReader {
         }
 
         /**
-         * The data for the column. Obtained by invoking {@link Sink#getUnderlying} on the {@link Sink}
-         * that built the column, after all processing is done.
+         * The data for the column. Obtained by invoking {@link Sink#getUnderlying} on the {@link Sink} that built the
+         * column, after all processing is done.
          */
         public Object data() {
             return data;

--- a/src/main/java/io/deephaven/csv/reading/CsvReader.java
+++ b/src/main/java/io/deephaven/csv/reading/CsvReader.java
@@ -12,6 +12,8 @@ import io.deephaven.csv.util.CsvReaderException;
 import io.deephaven.csv.util.MutableBoolean;
 import io.deephaven.csv.util.MutableObject;
 import io.deephaven.csv.util.Renderer;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.util.*;
@@ -299,7 +301,7 @@ public final class CsvReader {
     }
 
     /** Result of {@link #read}. Represents a set of columns. */
-    public static final class Result {
+    public static final class Result implements Iterable<ResultColumn> {
         private final long numRows;
         private final ResultColumn[] columns;
 
@@ -321,6 +323,12 @@ public final class CsvReader {
         /** The columns. */
         public ResultColumn[] columns() {
             return columns;
+        }
+
+        @NotNull
+        @Override
+        public Iterator<ResultColumn> iterator() {
+            return Arrays.stream(columns).iterator();
         }
     }
 

--- a/src/main/java/io/deephaven/csv/sinks/ArraySinkFactory.java
+++ b/src/main/java/io/deephaven/csv/sinks/ArraySinkFactory.java
@@ -1,0 +1,458 @@
+package io.deephaven.csv.sinks;
+
+import io.deephaven.csv.util.MutableObject;
+
+import java.lang.reflect.Array;
+import java.util.function.IntFunction;
+
+public class ArraySinkFactory implements SinkFactory {
+    private final Byte byteSentinel;
+    private final Short shortSentinel;
+    private final Integer intSentinel;
+    private final Long longSentinel;
+    private final Float floatSentinel;
+    private final Double doubleSentinel;
+    private final Byte booleanAsByteSentinel;
+    private final Character charSentinel;
+    private final String stringSentinel;
+    private final Long dateTimeAsLongSentinel;
+    private final Long timestampAsLongSentinel;
+
+    public ArraySinkFactory(Byte byteSentinel, Short shortSentinel, Integer intSentinel, Long longSentinel,
+            Float floatSentinel, Double doubleSentinel,
+            Byte booleanAsByteSentinel,
+            Character charSentinel, String stringSentinel, Long dateTimeAsLongSentinel, Long timestampAsLongSentinel) {
+        this.byteSentinel = byteSentinel;
+        this.shortSentinel = shortSentinel;
+        this.intSentinel = intSentinel;
+        this.longSentinel = longSentinel;
+        this.floatSentinel = floatSentinel;
+        this.doubleSentinel = doubleSentinel;
+        this.booleanAsByteSentinel = booleanAsByteSentinel;
+        this.charSentinel = charSentinel;
+        this.stringSentinel = stringSentinel;
+        this.dateTimeAsLongSentinel = dateTimeAsLongSentinel;
+        this.timestampAsLongSentinel = timestampAsLongSentinel;
+    }
+
+    @Override
+    public Sink<byte[]> forByte(MutableObject<Source<byte[]>> source) {
+        final ArrayByteSink result = new ArrayByteSink(byteSentinel);
+        source.setValue(result);
+        return result;
+    }
+
+    @Override
+    public Byte reservedByte() {
+        return byteSentinel;
+    }
+
+    @Override
+    public Sink<short[]> forShort(MutableObject<Source<short[]>> source) {
+        final ArrayShortSink result = new ArrayShortSink(shortSentinel);
+        source.setValue(result);
+        return result;
+    }
+
+    @Override
+    public Short reservedShort() {
+        return shortSentinel;
+    }
+
+    @Override
+    public Sink<int[]> forInt(MutableObject<Source<int[]>> source) {
+        final ArrayIntSink result = new ArrayIntSink(intSentinel);
+        source.setValue(result);
+        return result;
+    }
+
+    @Override
+    public Integer reservedInt() {
+        return intSentinel;
+    }
+
+    @Override
+    public Sink<long[]> forLong(MutableObject<Source<long[]>> source) {
+        final ArrayLongSink result = new ArrayLongSink(longSentinel);
+        source.setValue(result);
+        return result;
+    }
+
+    @Override
+    public Long reservedLong() {
+        return longSentinel;
+    }
+
+    @Override
+    public Sink<float[]> forFloat() {
+        return new ArrayFloatSink(floatSentinel);
+    }
+
+    @Override
+    public Float reservedFloat() {
+        return floatSentinel;
+    }
+
+    @Override
+    public Sink<double[]> forDouble() {
+        return new ArrayDoubleSink(doubleSentinel);
+    }
+
+    @Override
+    public Double reservedDouble() {
+        return doubleSentinel;
+    }
+
+    @Override
+    public Sink<byte[]> forBooleanAsByte() {
+        return new ArrayBooleanAsByteSink(booleanAsByteSentinel);
+    }
+
+    @Override
+    public Sink<char[]> forChar() {
+        return new ArrayCharSink(charSentinel);
+    }
+
+    @Override
+    public Character reservedChar() {
+        return charSentinel;
+    }
+
+    @Override
+    public Sink<String[]> forString() {
+        return new ArrayStringSink(stringSentinel);
+    }
+
+    @Override
+    public String reservedString() {
+        return stringSentinel;
+    }
+
+    @Override
+    public Sink<long[]> forDateTimeAsLong() {
+        return new ArrayDateTimeAsLongSink(dateTimeAsLongSentinel);
+    }
+
+    @Override
+    public Long reservedDateTimeAsLong() {
+        return dateTimeAsLongSentinel;
+    }
+
+    @Override
+    public Sink<long[]> forTimestampAsLong() {
+        return new ArrayTimestampAsLongSink(timestampAsLongSentinel);
+    }
+
+    @Override
+    public Long reservedTimestampAsLong() {
+        return timestampAsLongSentinel;
+    }
+}
+
+
+abstract class ArraySinkBase<TARRAY> implements Sink<TARRAY> {
+    private final int INITIAL_SIZE = 1024;
+
+    private final IntFunction<TARRAY> arrayFactory;
+    protected final boolean hasNullSentinel;
+    protected TARRAY array;
+
+    protected ArraySinkBase(final IntFunction<TARRAY> arrayFactory, final boolean hasNullSentinel) {
+        this.arrayFactory = arrayFactory;
+        this.hasNullSentinel = hasNullSentinel;
+        this.array = arrayFactory.apply(INITIAL_SIZE);
+    }
+
+    @Override
+    public final void write(
+            final TARRAY src,
+            final boolean[] isNull,
+            final long destBegin,
+            final long destEnd,
+            boolean appending) {
+        if (destBegin == destEnd) {
+            return;
+        }
+        final int destBeginAsInt = Math.toIntExact(destBegin);
+        final int destEndAsInt = Math.toIntExact(destEnd);
+        final int destSize = Math.toIntExact(destEnd - destBegin);
+
+        final int currentCapacity = Array.getLength(array);
+
+        // Grow array if needed.
+        if (currentCapacity < destEnd) {
+            final int highBit = Integer.highestOneBit(destEndAsInt);
+            final int newCapacity = destEndAsInt == highBit ? destEndAsInt : destEndAsInt * 2;
+            final TARRAY newArray = arrayFactory.apply(newCapacity);
+            System.arraycopy(array, 0, newArray, 0, currentCapacity);
+            array = newArray;
+        }
+
+        // User-friendly null sentinel check
+        if (hasNullSentinel) {
+            // Fix null sentinels if necessary.
+            nullFlagsToValues(isNull, src, destSize);
+        } else {
+            for (int i = 0; i < destSize; ++i) {
+                if (isNull[i]) {
+                    throw new RuntimeException(
+                            "The input contains a null value, but sink is not configured with a null sentinel value");
+                }
+            }
+        }
+
+        // Write chunk to storage.
+        System.arraycopy(src, 0, array, destBeginAsInt, destSize);
+    }
+
+    @Override
+    public final Object getUnderlying() {
+        return array;
+    }
+
+    protected abstract void nullFlagsToValues(
+            final boolean[] isNull, final TARRAY values, final int size);
+}
+
+
+abstract class ArraySourceAndSinkBase<TARRAY> extends ArraySinkBase<TARRAY>
+        implements io.deephaven.csv.sinks.Source<TARRAY>, Sink<TARRAY> {
+
+    protected ArraySourceAndSinkBase(final IntFunction<TARRAY> arrayFactory, final boolean hasNullSentinel) {
+        super(arrayFactory, hasNullSentinel);
+    }
+
+    @Override
+    public void read(TARRAY dest, boolean[] isNull, long srcBegin, long srcEnd) {
+        if (srcBegin == srcEnd) {
+            return;
+        }
+        final int srcBeginAsInt = Math.toIntExact(srcBegin);
+        final int srcSize = Math.toIntExact(srcEnd - srcBegin);
+
+        // Copy data to dest.
+        System.arraycopy(array, srcBeginAsInt, dest, 0, srcSize);
+        if (hasNullSentinel) {
+            nullValuesToFlags(dest, isNull, srcSize);
+        }
+    }
+
+    protected abstract void nullValuesToFlags(
+            final TARRAY values, final boolean[] isNull, final int size);
+}
+
+
+class ArrayByteSinkBase extends ArraySourceAndSinkBase<byte[]> {
+    protected final Byte nullSentinel;
+
+    public ArrayByteSinkBase(final Byte nullSentinel) {
+        super(byte[]::new, nullSentinel != null);
+        this.nullSentinel = nullSentinel;
+    }
+
+    @Override
+    protected final void nullFlagsToValues(boolean[] isNull, byte[] values, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            if (isNull[ii]) {
+                values[ii] = nullSentinel;
+            }
+        }
+    }
+
+    @Override
+    protected final void nullValuesToFlags(byte[] values, boolean[] isNull, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            isNull[ii] = values[ii] == nullSentinel;
+        }
+    }
+}
+
+
+final class ArrayByteSink extends ArrayByteSinkBase {
+    public ArrayByteSink(final Byte nullSentinel) {
+        super(nullSentinel);
+    }
+}
+
+
+final class ArrayShortSink extends ArraySourceAndSinkBase<short[]> {
+    private final Short nullSentinel;
+
+    public ArrayShortSink(final Short nullSentinel) {
+        super(short[]::new, nullSentinel != null);
+        this.nullSentinel = nullSentinel;
+    }
+
+    @Override
+    protected void nullFlagsToValues(boolean[] isNull, short[] values, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            if (isNull[ii]) {
+                values[ii] = nullSentinel;
+            }
+        }
+    }
+
+    @Override
+    protected void nullValuesToFlags(short[] values, boolean[] isNull, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            isNull[ii] = values[ii] == nullSentinel;
+        }
+    }
+}
+
+
+final class ArrayIntSink extends ArraySourceAndSinkBase<int[]> {
+    private final Integer nullSentinel;
+
+    public ArrayIntSink(final Integer nullSentinel) {
+        super(int[]::new, nullSentinel != null);
+        this.nullSentinel = nullSentinel;
+    }
+
+    @Override
+    protected void nullFlagsToValues(boolean[] isNull, int[] values, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            if (isNull[ii]) {
+                values[ii] = nullSentinel;
+            }
+        }
+    }
+
+    @Override
+    protected void nullValuesToFlags(int[] values, boolean[] isNull, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            isNull[ii] = values[ii] == nullSentinel;
+        }
+    }
+}
+
+
+class ArrayLongSinkBase extends ArraySourceAndSinkBase<long[]> {
+    private final Long nullSentinel;
+
+    public ArrayLongSinkBase(final Long nullSentinel) {
+        super(long[]::new, nullSentinel != null);
+        this.nullSentinel = nullSentinel;
+    }
+
+    @Override
+    protected final void nullFlagsToValues(boolean[] isNull, long[] values, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            if (isNull[ii]) {
+                values[ii] = nullSentinel;
+            }
+        }
+    }
+
+    @Override
+    protected final void nullValuesToFlags(long[] values, boolean[] isNull, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            isNull[ii] = values[ii] == nullSentinel;
+        }
+    }
+}
+
+
+final class ArrayLongSink extends ArrayLongSinkBase {
+    public ArrayLongSink(final Long nullSentinel) {
+        super(nullSentinel);
+    }
+}
+
+
+final class ArrayFloatSink extends ArraySinkBase<float[]> {
+    private final Float nullSentinel;
+
+    public ArrayFloatSink(final Float nullSentinel) {
+        super(float[]::new, nullSentinel != null);
+        this.nullSentinel = nullSentinel;
+    }
+
+    @Override
+    protected void nullFlagsToValues(boolean[] isNull, float[] values, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            if (isNull[ii]) {
+                values[ii] = nullSentinel;
+            }
+        }
+    }
+}
+
+
+final class ArrayDoubleSink extends ArraySinkBase<double[]> {
+    private final Double nullSentinel;
+
+    public ArrayDoubleSink(final Double nullSentinel) {
+        super(double[]::new, nullSentinel != null);
+        this.nullSentinel = nullSentinel;
+    }
+
+    @Override
+    protected void nullFlagsToValues(boolean[] isNull, double[] values, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            if (isNull[ii]) {
+                values[ii] = nullSentinel;
+            }
+        }
+    }
+}
+
+
+final class ArrayBooleanAsByteSink extends ArrayByteSinkBase {
+    public ArrayBooleanAsByteSink(final Byte nullSentinel) {
+        super(nullSentinel);
+    }
+}
+
+
+final class ArrayCharSink extends ArraySinkBase<char[]> {
+    private final Character nullSentinel;
+
+    public ArrayCharSink(final Character nullSentinel) {
+        super(char[]::new, nullSentinel != null);
+        this.nullSentinel = nullSentinel;
+    }
+
+    @Override
+    protected void nullFlagsToValues(boolean[] isNull, char[] values, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            if (isNull[ii]) {
+                values[ii] = nullSentinel;
+            }
+        }
+    }
+}
+
+
+final class ArrayStringSink extends ArraySinkBase<String[]> {
+    private final String nullSentinel;
+
+    public ArrayStringSink(final String nullSentinel) {
+        // true because for Strings, "null" is a legitimate and reasonable "null sentinel".
+        super(String[]::new, true);
+        this.nullSentinel = nullSentinel;
+    }
+
+    @Override
+    protected void nullFlagsToValues(boolean[] isNull, String[] values, int size) {
+        for (int ii = 0; ii < size; ++ii) {
+            if (isNull[ii]) {
+                values[ii] = nullSentinel;
+            }
+        }
+    }
+}
+
+
+final class ArrayDateTimeAsLongSink extends ArrayLongSinkBase {
+    public ArrayDateTimeAsLongSink(final Long nullSentinel) {
+        super(nullSentinel);
+    }
+}
+
+
+final class ArrayTimestampAsLongSink extends ArrayLongSinkBase {
+    public ArrayTimestampAsLongSink(final Long nullSentinel) {
+        super(nullSentinel);
+    }
+}

--- a/src/main/java/io/deephaven/csv/sinks/ArraySinkFactory.java
+++ b/src/main/java/io/deephaven/csv/sinks/ArraySinkFactory.java
@@ -18,7 +18,9 @@ public class ArraySinkFactory implements SinkFactory {
     private final Long dateTimeAsLongSentinel;
     private final Long timestampAsLongSentinel;
 
-    public ArraySinkFactory(Byte byteSentinel, Short shortSentinel, Integer intSentinel, Long longSentinel, Float floatSentinel, Double doubleSentinel, Byte booleanAsByteSentinel, Character charSentinel, String stringSentinel, Long dateTimeAsLongSentinel, Long timestampAsLongSentinel) {
+    public ArraySinkFactory(Byte byteSentinel, Short shortSentinel, Integer intSentinel, Long longSentinel,
+            Float floatSentinel, Double doubleSentinel, Byte booleanAsByteSentinel, Character charSentinel,
+            String stringSentinel, Long dateTimeAsLongSentinel, Long timestampAsLongSentinel) {
         this.byteSentinel = byteSentinel;
         this.shortSentinel = shortSentinel;
         this.intSentinel = intSentinel;

--- a/src/main/java/io/deephaven/csv/sinks/ArraySinkFactory.java
+++ b/src/main/java/io/deephaven/csv/sinks/ArraySinkFactory.java
@@ -18,10 +18,7 @@ public class ArraySinkFactory implements SinkFactory {
     private final Long dateTimeAsLongSentinel;
     private final Long timestampAsLongSentinel;
 
-    public ArraySinkFactory(Byte byteSentinel, Short shortSentinel, Integer intSentinel, Long longSentinel,
-            Float floatSentinel, Double doubleSentinel,
-            Byte booleanAsByteSentinel,
-            Character charSentinel, String stringSentinel, Long dateTimeAsLongSentinel, Long timestampAsLongSentinel) {
+    public ArraySinkFactory(Byte byteSentinel, Short shortSentinel, Integer intSentinel, Long longSentinel, Float floatSentinel, Double doubleSentinel, Byte booleanAsByteSentinel, Character charSentinel, String stringSentinel, Long dateTimeAsLongSentinel, Long timestampAsLongSentinel) {
         this.byteSentinel = byteSentinel;
         this.shortSentinel = shortSentinel;
         this.intSentinel = intSentinel;
@@ -151,7 +148,7 @@ public class ArraySinkFactory implements SinkFactory {
 
 
 abstract class ArraySinkBase<TARRAY> implements Sink<TARRAY> {
-    private final int INITIAL_SIZE = 1024;
+    private static final int INITIAL_SIZE = 1024;
 
     private final IntFunction<TARRAY> arrayFactory;
     protected final boolean hasNullSentinel;
@@ -180,9 +177,9 @@ abstract class ArraySinkBase<TARRAY> implements Sink<TARRAY> {
         final int currentCapacity = Array.getLength(array);
 
         // Grow array if needed.
-        if (currentCapacity < destEnd) {
+        if (currentCapacity < destEndAsInt) {
             final int highBit = Integer.highestOneBit(destEndAsInt);
-            final int newCapacity = destEndAsInt == highBit ? destEndAsInt : destEndAsInt * 2;
+            final int newCapacity = destEndAsInt == highBit ? highBit : highBit * 2;
             final TARRAY newArray = arrayFactory.apply(newCapacity);
             System.arraycopy(array, 0, newArray, 0, currentCapacity);
             array = newArray;

--- a/src/main/java/io/deephaven/csv/sinks/Sink.java
+++ b/src/main/java/io/deephaven/csv/sinks/Sink.java
@@ -65,8 +65,8 @@ public interface Sink<TARRAY> {
 
     /**
      * Returns the underlying data structure where the data is being stored. The value to be returned is at the
-     * discretion of the Sink implementor. The library doesn't look at this value; just passes it through to
-     * the {@link io.deephaven.csv.reading.CsvReader.ResultColumn} data structure.
+     * discretion of the Sink implementor. The library doesn't look at this value; just passes it through to the
+     * {@link io.deephaven.csv.reading.CsvReader.ResultColumn} data structure.
      *
      * @return The underlying data structure being built (implementation-defined).
      */

--- a/src/main/java/io/deephaven/csv/sinks/Sink.java
+++ b/src/main/java/io/deephaven/csv/sinks/Sink.java
@@ -62,4 +62,6 @@ public interface Sink<TARRAY> {
             final long destBegin,
             final long destEnd,
             boolean appending);
+
+    Object getUnderlying();
 }

--- a/src/main/java/io/deephaven/csv/sinks/Sink.java
+++ b/src/main/java/io/deephaven/csv/sinks/Sink.java
@@ -63,5 +63,12 @@ public interface Sink<TARRAY> {
             final long destEnd,
             boolean appending);
 
+    /**
+     * Returns the underlying data structure where the data is being stored. The value to be returned is at the
+     * discretion of the Sink implementor. The library doesn't look at this value; just passes it through to
+     * the {@link io.deephaven.csv.reading.CsvReader.ResultColumn} data structure.
+     *
+     * @return The underlying data structure being built (implementation-defined).
+     */
     Object getUnderlying();
 }

--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -1715,14 +1715,14 @@ public class CsvReaderTest {
      */
     private static ColumnSet toColumnSet(final CsvReader.Result result, MakeCustomColumn makeCustomColumn) {
         final int numCols = result.numCols();
+        final CsvReader.ResultColumn[] resultColumns = result.columns();
 
         final Column<?>[] columns = new Column[numCols];
         final int sizeAsInt = Math.toIntExact(result.numRows());
+
         for (int ii = 0; ii < numCols; ++ii) {
-            final String columnName = result.columnNames()[ii];
-            final DataType dataType = result.dataTypes()[ii];
-            final Object col = result.columns()[ii];
-            columns[ii] = makeColumn(columnName, dataType, col, sizeAsInt, makeCustomColumn);
+            final CsvReader.ResultColumn rc = resultColumns[ii];
+            columns[ii] = makeColumn(rc.name(), rc.dataType(), rc.data(), sizeAsInt, makeCustomColumn);
         }
         return ColumnSet.of(columns);
     }


### PR DESCRIPTION
As a type inference performance optimization, four Sink types are required to also implement Source, so the algorithm can read their data back directly rather than reparsing. Those four types are byte, short, int, long.

This change makes that behavior optional. If an implementer doesn't want to (or can't) implement Source for their type, the system will fall back to two-phase parsing.

For example there may be some Sinks (like writing to file) where the user really doesn't want to go seek and fetch the data back.