### PR TITLE
Alter logic so we don't call tryEnsureMore() after finish().

### DIFF
--- a/src/main/java/io/deephaven/csv/reading/CellGrabber.java
+++ b/src/main/java/io/deephaven/csv/reading/CellGrabber.java
@@ -162,10 +162,8 @@ final class CellGrabber {
         finishField(dest, lastInRow);
 
         // From this point on, note that dest is a slice that may point to the underlying input buffer
-        // or the spill
-        // buffer. Take care from this point on to not disturb the input (e.g. by reading the next
-        // chunk) or the
-        // spill buffer.
+        // or the spill buffer. Take care from this point on to not disturb the input (e.g. by reading
+        // the next chunk) or the spill buffer.
 
         // The easiest way to make all the above logic run smoothly is to let the final quotation mark
         // (which will unconditionally be there) and subsequent whitespace (if any) into the field.
@@ -236,14 +234,20 @@ final class CellGrabber {
                 return;
             }
             if (ch == '\r') {
-                finish(dest);
+                // This is slightly complicated because we have to look ahead for a possible \n.
+                // The easiest way to deal with this is to let it into our slice and then trim it
+                // off at the end.
                 ++offset;
+                int excess = 1;
                 if (tryEnsureMore()) {
                     // might be \r\n
                     if (buffer[offset] == '\n') {
                         ++offset;
+                        excess = 2;
                     }
                 }
+                finish(dest);
+                dest.reset(dest.data(), dest.begin(), dest.end() - excess);
                 lastInRow.setValue(true);
                 ++physicalRowNum;
                 return;

--- a/src/main/java/io/deephaven/csv/reading/CellGrabber.java
+++ b/src/main/java/io/deephaven/csv/reading/CellGrabber.java
@@ -13,9 +13,9 @@ import java.io.InputStream;
  * This class is used to traverse over text from a Reader, understanding both field and line delimiters, as well as the
  * CSV quoting convention, and breaking the text into cells for use by the calling code.
  */
-final class CellGrabber {
+public final class CellGrabber {
     /** Size of chunks to read from the {@link InputStream}. */
-    private static final int BUFFER_SIZE = 65536;
+    public static final int BUFFER_SIZE = 65536;
     /** The {@link InputStream} for the input. */
     private final InputStream inputStream;
     /** The configured CSV quote character (typically '"'). Must be 7-bit ASCII. */

--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -11,6 +11,7 @@ import io.deephaven.csv.parsers.DataType;
 import io.deephaven.csv.parsers.IteratorHolder;
 import io.deephaven.csv.parsers.Parser;
 import io.deephaven.csv.parsers.Parsers;
+import io.deephaven.csv.reading.CellGrabber;
 import io.deephaven.csv.reading.CsvReader;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.sinks.SinkFactory;
@@ -46,6 +47,26 @@ public class CsvReaderTest {
         public static final char NULL_CHAR = Character.MAX_VALUE;
         public static final long NULL_DATETIME_AS_LONG = Long.MIN_VALUE;
         public static final long NULL_TIMESTAMP_AS_LONG = Long.MIN_VALUE;
+    }
+
+    /**
+     * https://github.com/deephaven/deephaven-core/issues/2133
+     */
+    @Test
+    public void bug2133() throws CsvReaderException {
+        final int bufferSize = CellGrabber.BUFFER_SIZE;
+        final StringBuilder sb = new StringBuilder("Values\r");
+        final int numAs = bufferSize - sb.length() - 1;
+        final String expected1 = "a".repeat(numAs);
+        final String expected2 = "b".repeat(bufferSize);
+        sb.append(expected1).append('\r').append(expected2).append('\r');
+        final String input = sb.toString();
+        final CsvReader.Result result = parse(defaultCsvSpecs(), toInputStream(input));
+        final String[] col = (String[])result.columns()[0].data();
+        final String row1 = col[0];
+        final String row2 = col[1];
+        Assertions.assertThat(row1).isEqualTo(expected1);
+        Assertions.assertThat(row2).isEqualTo(expected2);
     }
 
     @Test

--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -62,7 +62,7 @@ public class CsvReaderTest {
         sb.append(expected1).append('\r').append(expected2).append('\r');
         final String input = sb.toString();
         final CsvReader.Result result = parse(defaultCsvSpecs(), toInputStream(input));
-        final String[] col = (String[])result.columns()[0].data();
+        final String[] col = (String[]) result.columns()[0].data();
         final String row1 = col[0];
         final String row2 = col[1];
         Assertions.assertThat(row1).isEqualTo(expected1);


### PR DESCRIPTION
When conditions are right, namely your buffer ends right at the \n, this will corrupt the slice we're trying to return.

This is the root cause of https://github.com/deephaven/deephaven-core/issues/2133
