### PR TITLE
Allow Sinks to know which column they are associated with.

### DIFF
--- a/src/jmh/java/io/deephaven/csv/benchmark/util/SinkFactories.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/util/SinkFactories.java
@@ -4,7 +4,7 @@ import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.sinks.Source;
 import io.deephaven.csv.sinks.SinkFactory;
 
-import java.util.function.Supplier;
+import java.util.function.IntFunction;
 
 public final class SinkFactories {
     public static SinkFactory makeRecyclingSinkFactory(byte[][] byteBuffers, int[][] intBuffers, long[][] longBuffers,
@@ -26,11 +26,11 @@ public final class SinkFactories {
     private interface SourceSink<TARRAY> extends Source<TARRAY>, Sink<TARRAY> {
     }
 
-    private static <TARRAY> Supplier<SourceSink<TARRAY>> makeSupplier(final TARRAY[] buffers) {
+    private static <TARRAY> IntFunction<SourceSink<TARRAY>> makeSupplier(final TARRAY[] buffers) {
         return buffers == null ? null : new RecyclingSinkSupplier<>(buffers);
     }
 
-    private static final class RecyclingSinkSupplier<TARRAY> implements Supplier<SourceSink<TARRAY>> {
+    private static final class RecyclingSinkSupplier<TARRAY> implements IntFunction<SourceSink<TARRAY>> {
         private final TARRAY[] buffers;
         private int nextIndex;
 
@@ -40,7 +40,7 @@ public final class SinkFactories {
         }
 
         @Override
-        public SourceSink<TARRAY> get() {
+        public SourceSink<TARRAY> apply(final int colNum) {
             if (nextIndex == buffers.length) {
                 throw new RuntimeException("Ran out of buffers");
             }

--- a/src/main/java/io/deephaven/csv/CsvSpecs.java
+++ b/src/main/java/io/deephaven/csv/CsvSpecs.java
@@ -35,8 +35,7 @@ public abstract class CsvSpecs {
         Builder headers(Iterable<String> elements);
 
         /**
-         * Override a specific column header by number. This is applied after {@link #headers()}. Column numbers start
-         * with 1.
+         * Override a specific column header by 0-based column index. This is applied after {@link #headers()}.
          */
         Builder putHeaderForIndex(int index, String header);
 
@@ -61,8 +60,8 @@ public abstract class CsvSpecs {
         Builder putParserForName(String columnName, Parser<?> parser);
 
         /**
-         * Used to force a specific parser for a specific column, specified by column number. Column numbers start with
-         * 1. Specifying a parser forgoes column inference for that column.
+         * Used to force a specific parser for a specific column, specified by 0-based column index. Specifying a parser
+         * forgoes column inference for that column.
          */
         Builder putParserForIndex(int index, Parser<?> parser);
 
@@ -82,7 +81,7 @@ public abstract class CsvSpecs {
         Builder putNullValueLiteralsForName(String columnName, List<String> nullValueLiteral);
 
         /**
-         * The null value literal for specific columns, specified by 1-based column index. Specifying a null value
+         * The null value literal for specific columns, specified by 0-based column index. Specifying a null value
          * literal for a column overrides the value in {@link #nullValueLiterals()}.
          */
         Builder putNullValueLiteralsForIndex(int index, List<String> nullValueLiteral);

--- a/src/main/java/io/deephaven/csv/parsers/BooleanAsByteParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/BooleanAsByteParser.java
@@ -16,7 +16,7 @@ public final class BooleanAsByteParser implements Parser<byte[]> {
     @NotNull
     @Override
     public ParserContext<byte[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<byte[]> sink = gctx.sinkFactory.forBooleanAsByte();
+        final Sink<byte[]> sink = gctx.sinkFactory.forBooleanAsByte(gctx.colNum);
         return new ParserContext<>(sink, null, DataType.BOOLEAN_AS_BYTE, new byte[chunkSize]);
     }
 

--- a/src/main/java/io/deephaven/csv/parsers/BooleanAsByteParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/BooleanAsByteParser.java
@@ -1,6 +1,5 @@
 package io.deephaven.csv.parsers;
 
-import io.deephaven.csv.reading.CsvReader;
 import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.tokenization.Tokenizer;
 import io.deephaven.csv.util.CsvReaderException;
@@ -16,7 +15,7 @@ public final class BooleanAsByteParser implements Parser<byte[]> {
     @NotNull
     @Override
     public ParserContext<byte[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<byte[]> sink = gctx.sinkFactory.forBooleanAsByte(gctx.colNum);
+        final Sink<byte[]> sink = gctx.sinkFactory().forBooleanAsByte(gctx.colNum());
         return new ParserContext<>(sink, null, DataType.BOOLEAN_AS_BYTE, new byte[chunkSize]);
     }
 
@@ -30,7 +29,7 @@ public final class BooleanAsByteParser implements Parser<byte[]> {
             final boolean appending)
             throws CsvReaderException {
         final MutableBoolean booleanHolder = new MutableBoolean();
-        final Tokenizer t = gctx.tokenizer;
+        final Tokenizer t = gctx.tokenizer();
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<byte[]> sink = pctx.sink();
@@ -54,7 +53,7 @@ public final class BooleanAsByteParser implements Parser<byte[]> {
             if (!t.tryParseBoolean(ih.bs(), booleanHolder)) {
                 break;
             }
-            gctx.isNullOrWidthOneSoFar = false;
+            gctx.clearIsNullOrWidthOneSoFar();
             values[chunkIndex] = booleanHolder.booleanValue() ? (byte) 1 : (byte) 0;
             nulls[chunkIndex] = false;
             ++chunkIndex;

--- a/src/main/java/io/deephaven/csv/parsers/ByteParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/ByteParser.java
@@ -19,7 +19,7 @@ public final class ByteParser implements Parser<byte[]> {
     @Override
     public ParserContext<byte[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<byte[]>> sourceHolder = new MutableObject<>();
-        final Sink<byte[]> sink = gctx.sinkFactory.forByte(sourceHolder);
+        final Sink<byte[]> sink = gctx.sinkFactory.forByte(gctx.colNum, sourceHolder);
         return new ParserContext<>(sink, sourceHolder.getValue(), DataType.BYTE, new byte[chunkSize]);
     }
 

--- a/src/main/java/io/deephaven/csv/parsers/ByteParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/ByteParser.java
@@ -19,7 +19,7 @@ public final class ByteParser implements Parser<byte[]> {
     @Override
     public ParserContext<byte[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<byte[]>> sourceHolder = new MutableObject<>();
-        final Sink<byte[]> sink = gctx.sinkFactory.forByte(gctx.colNum, sourceHolder);
+        final Sink<byte[]> sink = gctx.sinkFactory().forByte(gctx.colNum(), sourceHolder);
         return new ParserContext<>(sink, sourceHolder.getValue(), DataType.BYTE, new byte[chunkSize]);
     }
 
@@ -33,11 +33,11 @@ public final class ByteParser implements Parser<byte[]> {
             final boolean appending)
             throws CsvReaderException {
         final MutableLong longHolder = new MutableLong();
-        final Tokenizer t = gctx.tokenizer;
+        final Tokenizer t = gctx.tokenizer();
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<byte[]> sink = pctx.sink();
-        final Byte reservedValue = gctx.sinkFactory.reservedByte();
+        final Byte reservedValue = gctx.sinkFactory().reservedByte();
         final byte[] values = pctx.valueChunk();
 
         long current = begin;
@@ -67,7 +67,7 @@ public final class ByteParser implements Parser<byte[]> {
                 break;
             }
             if (ih.bs().size() != 1) {
-                gctx.isNullOrWidthOneSoFar = false;
+                gctx.clearIsNullOrWidthOneSoFar();
             }
             values[chunkIndex] = (byte) value;
             nulls[chunkIndex] = false;

--- a/src/main/java/io/deephaven/csv/parsers/CharParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/CharParser.java
@@ -15,7 +15,7 @@ public final class CharParser implements Parser<char[]> {
     @NotNull
     @Override
     public ParserContext<char[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<char[]> sink = gctx.sinkFactory.forChar(gctx.colNum);
+        final Sink<char[]> sink = gctx.sinkFactory().forChar(gctx.colNum());
         return new ParserContext<>(sink, null, DataType.CHAR, new char[chunkSize]);
     }
 
@@ -29,14 +29,14 @@ public final class CharParser implements Parser<char[]> {
             final boolean appending)
             throws CsvReaderException {
         final MutableInt intHolder = new MutableInt();
-        final Tokenizer t = gctx.tokenizer;
+        final Tokenizer t = gctx.tokenizer();
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<char[]> sink = pctx.sink();
-        final Character reservedValue = gctx.sinkFactory.reservedChar();
+        final Character reservedValue = gctx.sinkFactory().reservedChar();
         final char[] values = pctx.valueChunk();
 
-        if (!gctx.isNullOrWidthOneSoFar) {
+        if (!gctx.isNullOrWidthOneSoFar()) {
             return begin;
         }
 
@@ -56,7 +56,7 @@ public final class CharParser implements Parser<char[]> {
                 continue;
             }
             if (!t.tryParseBMPChar(ih.bs(), intHolder)) {
-                gctx.isNullOrWidthOneSoFar = false;
+                gctx.clearIsNullOrWidthOneSoFar();
                 break;
             }
             final char value = (char) intHolder.intValue();

--- a/src/main/java/io/deephaven/csv/parsers/CharParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/CharParser.java
@@ -15,7 +15,7 @@ public final class CharParser implements Parser<char[]> {
     @NotNull
     @Override
     public ParserContext<char[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<char[]> sink = gctx.sinkFactory.forChar();
+        final Sink<char[]> sink = gctx.sinkFactory.forChar(gctx.colNum);
         return new ParserContext<>(sink, null, DataType.CHAR, new char[chunkSize]);
     }
 

--- a/src/main/java/io/deephaven/csv/parsers/DateTimeAsLongParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/DateTimeAsLongParser.java
@@ -15,7 +15,7 @@ public final class DateTimeAsLongParser implements Parser<long[]> {
     @NotNull
     @Override
     public ParserContext<long[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<long[]> sink = gctx.sinkFactory.forDateTimeAsLong();
+        final Sink<long[]> sink = gctx.sinkFactory.forDateTimeAsLong(gctx.colNum);
         return new ParserContext<>(sink, null, DataType.DATETIME_AS_LONG, new long[chunkSize]);
     }
 
@@ -33,7 +33,7 @@ public final class DateTimeAsLongParser implements Parser<long[]> {
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<long[]> sink = pctx.sink();
-        final Long reservedValue = gctx.sinkFactory.reservedLong();
+        final Long reservedValue = gctx.sinkFactory.reservedDateTimeAsLong();
         final long[] values = pctx.valueChunk();
 
         long current = begin;

--- a/src/main/java/io/deephaven/csv/parsers/DateTimeAsLongParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/DateTimeAsLongParser.java
@@ -15,7 +15,7 @@ public final class DateTimeAsLongParser implements Parser<long[]> {
     @NotNull
     @Override
     public ParserContext<long[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<long[]> sink = gctx.sinkFactory.forDateTimeAsLong(gctx.colNum);
+        final Sink<long[]> sink = gctx.sinkFactory().forDateTimeAsLong(gctx.colNum());
         return new ParserContext<>(sink, null, DataType.DATETIME_AS_LONG, new long[chunkSize]);
     }
 
@@ -29,11 +29,11 @@ public final class DateTimeAsLongParser implements Parser<long[]> {
             final boolean appending)
             throws CsvReaderException {
         final MutableLong dateTimeAsLongHolder = new MutableLong();
-        final Tokenizer t = gctx.tokenizer;
+        final Tokenizer t = gctx.tokenizer();
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<long[]> sink = pctx.sink();
-        final Long reservedValue = gctx.sinkFactory.reservedDateTimeAsLong();
+        final Long reservedValue = gctx.sinkFactory().reservedDateTimeAsLong();
         final long[] values = pctx.valueChunk();
 
         long current = begin;
@@ -60,7 +60,7 @@ public final class DateTimeAsLongParser implements Parser<long[]> {
                 break;
             }
             if (ih.bs().size() > 1) {
-                gctx.isNullOrWidthOneSoFar = false;
+                gctx.clearIsNullOrWidthOneSoFar();
             }
             values[chunkIndex] = value;
             nulls[chunkIndex] = false;

--- a/src/main/java/io/deephaven/csv/parsers/DoubleParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/DoubleParser.java
@@ -15,7 +15,7 @@ public final class DoubleParser implements Parser<double[]> {
     @NotNull
     @Override
     public ParserContext<double[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<double[]> sink = gctx.sinkFactory.forDouble(gctx.colNum);
+        final Sink<double[]> sink = gctx.sinkFactory().forDouble(gctx.colNum());
         return new ParserContext<>(sink, null, DataType.DOUBLE, new double[chunkSize]);
     }
 
@@ -29,11 +29,11 @@ public final class DoubleParser implements Parser<double[]> {
             final boolean appending)
             throws CsvReaderException {
         final MutableDouble doubleHolder = new MutableDouble();
-        final Tokenizer t = gctx.tokenizer;
+        final Tokenizer t = gctx.tokenizer();
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<double[]> sink = pctx.sink();
-        final Double reservedValue = gctx.sinkFactory.reservedDouble();
+        final Double reservedValue = gctx.sinkFactory().reservedDouble();
         final double[] values = pctx.valueChunk();
 
         long current = begin;
@@ -60,7 +60,7 @@ public final class DoubleParser implements Parser<double[]> {
                 break;
             }
             if (ih.bs().size() > 1) {
-                gctx.isNullOrWidthOneSoFar = false;
+                gctx.clearIsNullOrWidthOneSoFar();
             }
             values[chunkIndex] = value;
             nulls[chunkIndex] = false;

--- a/src/main/java/io/deephaven/csv/parsers/DoubleParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/DoubleParser.java
@@ -15,7 +15,7 @@ public final class DoubleParser implements Parser<double[]> {
     @NotNull
     @Override
     public ParserContext<double[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<double[]> sink = gctx.sinkFactory.forDouble();
+        final Sink<double[]> sink = gctx.sinkFactory.forDouble(gctx.colNum);
         return new ParserContext<>(sink, null, DataType.DOUBLE, new double[chunkSize]);
     }
 

--- a/src/main/java/io/deephaven/csv/parsers/FloatFastParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/FloatFastParser.java
@@ -22,7 +22,7 @@ public final class FloatFastParser implements Parser<float[]> {
     @NotNull
     @Override
     public ParserContext<float[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<float[]> sink = gctx.sinkFactory.forFloat();
+        final Sink<float[]> sink = gctx.sinkFactory.forFloat(gctx.colNum);
         return new ParserContext<>(sink, null, DataType.FLOAT, new float[chunkSize]);
     }
 

--- a/src/main/java/io/deephaven/csv/parsers/FloatFastParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/FloatFastParser.java
@@ -22,7 +22,7 @@ public final class FloatFastParser implements Parser<float[]> {
     @NotNull
     @Override
     public ParserContext<float[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<float[]> sink = gctx.sinkFactory.forFloat(gctx.colNum);
+        final Sink<float[]> sink = gctx.sinkFactory().forFloat(gctx.colNum());
         return new ParserContext<>(sink, null, DataType.FLOAT, new float[chunkSize]);
     }
 
@@ -36,11 +36,11 @@ public final class FloatFastParser implements Parser<float[]> {
             final boolean appending)
             throws CsvReaderException {
         final MutableDouble doubleHolder = new MutableDouble();
-        final Tokenizer t = gctx.tokenizer;
+        final Tokenizer t = gctx.tokenizer();
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<float[]> sink = pctx.sink();
-        final Float reservedValue = gctx.sinkFactory.reservedFloat();
+        final Float reservedValue = gctx.sinkFactory().reservedFloat();
         final float[] values = pctx.valueChunk();
 
         long current = begin;
@@ -70,7 +70,7 @@ public final class FloatFastParser implements Parser<float[]> {
                 break;
             }
             if (ih.bs().size() > 1) {
-                gctx.isNullOrWidthOneSoFar = false;
+                gctx.clearIsNullOrWidthOneSoFar();
             }
             values[chunkIndex] = (float) value;
             nulls[chunkIndex] = false;

--- a/src/main/java/io/deephaven/csv/parsers/FloatStrictParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/FloatStrictParser.java
@@ -20,7 +20,7 @@ public final class FloatStrictParser implements Parser<float[]> {
     @NotNull
     @Override
     public ParserContext<float[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<float[]> sink = gctx.sinkFactory.forFloat(gctx.colNum);
+        final Sink<float[]> sink = gctx.sinkFactory().forFloat(gctx.colNum());
         return new ParserContext<>(sink, null, DataType.FLOAT, new float[chunkSize]);
     }
 
@@ -34,11 +34,11 @@ public final class FloatStrictParser implements Parser<float[]> {
             final boolean appending)
             throws CsvReaderException {
         final MutableFloat floatHolder = new MutableFloat();
-        final Tokenizer t = gctx.tokenizer;
+        final Tokenizer t = gctx.tokenizer();
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<float[]> sink = pctx.sink();
-        final Float reservedValue = gctx.sinkFactory.reservedFloat();
+        final Float reservedValue = gctx.sinkFactory().reservedFloat();
         final float[] values = pctx.valueChunk();
 
         long current = begin;
@@ -65,7 +65,7 @@ public final class FloatStrictParser implements Parser<float[]> {
                 break;
             }
             if (ih.bs().size() > 1) {
-                gctx.isNullOrWidthOneSoFar = false;
+                gctx.clearIsNullOrWidthOneSoFar();
             }
             values[chunkIndex] = value;
             nulls[chunkIndex] = false;

--- a/src/main/java/io/deephaven/csv/parsers/FloatStrictParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/FloatStrictParser.java
@@ -20,7 +20,7 @@ public final class FloatStrictParser implements Parser<float[]> {
     @NotNull
     @Override
     public ParserContext<float[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<float[]> sink = gctx.sinkFactory.forFloat();
+        final Sink<float[]> sink = gctx.sinkFactory.forFloat(gctx.colNum);
         return new ParserContext<>(sink, null, DataType.FLOAT, new float[chunkSize]);
     }
 

--- a/src/main/java/io/deephaven/csv/parsers/IntParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/IntParser.java
@@ -19,7 +19,7 @@ public final class IntParser implements Parser<int[]> {
     @Override
     public ParserContext<int[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<int[]>> sourceHolder = new MutableObject<>();
-        final Sink<int[]> sink = gctx.sinkFactory.forInt(sourceHolder);
+        final Sink<int[]> sink = gctx.sinkFactory.forInt(gctx.colNum, sourceHolder);
         return new ParserContext<>(sink, sourceHolder.getValue(), DataType.INT, new int[chunkSize]);
     }
 

--- a/src/main/java/io/deephaven/csv/parsers/IntParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/IntParser.java
@@ -19,7 +19,7 @@ public final class IntParser implements Parser<int[]> {
     @Override
     public ParserContext<int[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<int[]>> sourceHolder = new MutableObject<>();
-        final Sink<int[]> sink = gctx.sinkFactory.forInt(gctx.colNum, sourceHolder);
+        final Sink<int[]> sink = gctx.sinkFactory().forInt(gctx.colNum(), sourceHolder);
         return new ParserContext<>(sink, sourceHolder.getValue(), DataType.INT, new int[chunkSize]);
     }
 
@@ -33,11 +33,11 @@ public final class IntParser implements Parser<int[]> {
             final boolean appending)
             throws CsvReaderException {
         final MutableLong longHolder = new MutableLong();
-        final Tokenizer t = gctx.tokenizer;
+        final Tokenizer t = gctx.tokenizer();
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<int[]> sink = pctx.sink();
-        final Integer reservedValue = gctx.sinkFactory.reservedInt();
+        final Integer reservedValue = gctx.sinkFactory().reservedInt();
         final int[] values = pctx.valueChunk();
 
         long current = begin;
@@ -68,7 +68,7 @@ public final class IntParser implements Parser<int[]> {
             }
             if (ih.bs().size() > 1) {
                 // Not an error, but needed in case we eventually fall back to char.
-                gctx.isNullOrWidthOneSoFar = false;
+                gctx.clearIsNullOrWidthOneSoFar();
             }
             values[chunkIndex] = (int) value;
             nulls[chunkIndex] = false;

--- a/src/main/java/io/deephaven/csv/parsers/LongParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/LongParser.java
@@ -18,7 +18,7 @@ public final class LongParser implements Parser<long[]> {
     @Override
     public ParserContext<long[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<long[]>> sourceHolder = new MutableObject<>();
-        final Sink<long[]> sink = gctx.sinkFactory.forLong(gctx.colNum, sourceHolder);
+        final Sink<long[]> sink = gctx.sinkFactory().forLong(gctx.colNum(), sourceHolder);
         return new ParserContext<>(sink, sourceHolder.getValue(), DataType.LONG, new long[chunkSize]);
     }
 
@@ -32,11 +32,11 @@ public final class LongParser implements Parser<long[]> {
             final boolean appending)
             throws CsvReaderException {
         final MutableLong longHolder = new MutableLong();
-        final Tokenizer t = gctx.tokenizer;
+        final Tokenizer t = gctx.tokenizer();
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<long[]> sink = pctx.sink();
-        final Long reservedValue = gctx.sinkFactory.reservedLong();
+        final Long reservedValue = gctx.sinkFactory().reservedLong();
         final long[] values = pctx.valueChunk();
 
         long current = begin;
@@ -63,7 +63,7 @@ public final class LongParser implements Parser<long[]> {
                 break;
             }
             if (ih.bs().size() > 1) {
-                gctx.isNullOrWidthOneSoFar = false;
+                gctx.clearIsNullOrWidthOneSoFar();
             }
             values[chunkIndex] = value;
             nulls[chunkIndex] = false;

--- a/src/main/java/io/deephaven/csv/parsers/LongParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/LongParser.java
@@ -18,7 +18,7 @@ public final class LongParser implements Parser<long[]> {
     @Override
     public ParserContext<long[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<long[]>> sourceHolder = new MutableObject<>();
-        final Sink<long[]> sink = gctx.sinkFactory.forLong(sourceHolder);
+        final Sink<long[]> sink = gctx.sinkFactory.forLong(gctx.colNum, sourceHolder);
         return new ParserContext<>(sink, sourceHolder.getValue(), DataType.LONG, new long[chunkSize]);
     }
 

--- a/src/main/java/io/deephaven/csv/parsers/Parser.java
+++ b/src/main/java/io/deephaven/csv/parsers/Parser.java
@@ -76,20 +76,20 @@ public interface Parser<TARRAY> {
 
     class GlobalContext {
         /**
-         * The 1-based column number that the parser is working on.
+         * The 0-based column number that the parser is working on.
          */
-        public final int colNum;
+        private final int colNum;
         /**
          * The Tokenizer is responsible for parsing entities like ints, doubles, supported DateTime formats, etc.
          */
-        public final Tokenizer tokenizer;
+        private final Tokenizer tokenizer;
         /** Caller-specified interface for making all the various Sink&lt;TARRAY&gt; types. */
-        public final SinkFactory sinkFactory;
+        private final SinkFactory sinkFactory;
         /**
          * Whether all the cells seen so far are the "null" indicator (usually the empty string), or are 1 character in
          * length. This is used when inferring char vs String.
          */
-        public boolean isNullOrWidthOneSoFar;
+        private boolean isNullOrWidthOneSoFar;
         /**
          * The array of null sentinels, each encoded in UTF-8. The user can configure as many null sentinels as they
          * want (including no null sentinels).
@@ -132,6 +132,30 @@ public interface Parser<TARRAY> {
                 }
             }
             return false;
+        }
+
+        public int colNum() {
+            return colNum;
+        }
+
+        public Tokenizer tokenizer() {
+            return tokenizer;
+        }
+
+        public SinkFactory sinkFactory() {
+            return sinkFactory;
+        }
+
+        public boolean isNullOrWidthOneSoFar() {
+            return isNullOrWidthOneSoFar;
+        }
+
+        public void clearIsNullOrWidthOneSoFar() {
+            isNullOrWidthOneSoFar = false;
+        }
+
+        public byte[][] nullSentinelsAsBytes() {
+            return nullSentinelsAsBytes;
         }
 
         public boolean[] nullChunk() {

--- a/src/main/java/io/deephaven/csv/parsers/Parser.java
+++ b/src/main/java/io/deephaven/csv/parsers/Parser.java
@@ -23,7 +23,7 @@ public interface Parser<TARRAY> {
      * 
      * <pre>
      * final MySink sink = new MySink();
-     * return new ParserContext&lt;&gt;(sink, null, new MyType[chunkSize]);
+     * return new ParserContext&lt;&gt;(sink, null, DataType.XXXType, new MyType[chunkSize]);
      * </pre>
      * 
      * <p>
@@ -76,6 +76,10 @@ public interface Parser<TARRAY> {
 
     class GlobalContext {
         /**
+         * The 1-based column number that the parser is working on.
+         */
+        public final int colNum;
+        /**
          * The Tokenizer is responsible for parsing entities like ints, doubles, supported DateTime formats, etc.
          */
         public final Tokenizer tokenizer;
@@ -94,8 +98,9 @@ public interface Parser<TARRAY> {
         /** An "isNull" chunk */
         private final boolean[] nullChunk;
 
-        public GlobalContext(
-                final Tokenizer tokenizer, final SinkFactory sinkFactory, final String[] nullValueLiterals) {
+        public GlobalContext(final int colNum, final Tokenizer tokenizer, final SinkFactory sinkFactory,
+                final String[] nullValueLiterals) {
+            this.colNum = colNum;
             this.tokenizer = tokenizer;
             this.sinkFactory = sinkFactory;
             isNullOrWidthOneSoFar = true;

--- a/src/main/java/io/deephaven/csv/parsers/ShortParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/ShortParser.java
@@ -19,7 +19,7 @@ public final class ShortParser implements Parser<short[]> {
     @Override
     public ParserContext<short[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<short[]>> sourceHolder = new MutableObject<>();
-        final Sink<short[]> sink = gctx.sinkFactory.forShort(gctx.colNum, sourceHolder);
+        final Sink<short[]> sink = gctx.sinkFactory().forShort(gctx.colNum(), sourceHolder);
         return new ParserContext<>(sink, sourceHolder.getValue(), DataType.SHORT, new short[chunkSize]);
     }
 
@@ -33,11 +33,11 @@ public final class ShortParser implements Parser<short[]> {
             final boolean appending)
             throws CsvReaderException {
         final MutableLong longHolder = new MutableLong();
-        final Tokenizer t = gctx.tokenizer;
+        final Tokenizer t = gctx.tokenizer();
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<short[]> sink = pctx.sink();
-        final Short reservedValue = gctx.sinkFactory.reservedShort();
+        final Short reservedValue = gctx.sinkFactory().reservedShort();
         final short[] values = pctx.valueChunk();
 
         long current = begin;
@@ -67,7 +67,7 @@ public final class ShortParser implements Parser<short[]> {
                 break;
             }
             if (ih.bs().size() > 1) {
-                gctx.isNullOrWidthOneSoFar = false;
+                gctx.clearIsNullOrWidthOneSoFar();
             }
             values[chunkIndex] = (short) value;
             nulls[chunkIndex] = false;

--- a/src/main/java/io/deephaven/csv/parsers/ShortParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/ShortParser.java
@@ -19,7 +19,7 @@ public final class ShortParser implements Parser<short[]> {
     @Override
     public ParserContext<short[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
         final MutableObject<Source<short[]>> sourceHolder = new MutableObject<>();
-        final Sink<short[]> sink = gctx.sinkFactory.forShort(sourceHolder);
+        final Sink<short[]> sink = gctx.sinkFactory.forShort(gctx.colNum, sourceHolder);
         return new ParserContext<>(sink, sourceHolder.getValue(), DataType.SHORT, new short[chunkSize]);
     }
 

--- a/src/main/java/io/deephaven/csv/parsers/StringParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/StringParser.java
@@ -13,7 +13,7 @@ public final class StringParser implements Parser<String[]> {
     @NotNull
     @Override
     public ParserContext<String[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<String[]> sink = gctx.sinkFactory.forString(gctx.colNum);
+        final Sink<String[]> sink = gctx.sinkFactory().forString(gctx.colNum());
         return new ParserContext<>(sink, null, DataType.STRING, new String[chunkSize]);
     }
 
@@ -29,7 +29,7 @@ public final class StringParser implements Parser<String[]> {
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<String[]> sink = pctx.sink();
-        final String reservedValue = gctx.sinkFactory.reservedString();
+        final String reservedValue = gctx.sinkFactory().reservedString();
         final String[] values = pctx.valueChunk();
 
         long current = begin;

--- a/src/main/java/io/deephaven/csv/parsers/StringParser.java
+++ b/src/main/java/io/deephaven/csv/parsers/StringParser.java
@@ -13,7 +13,7 @@ public final class StringParser implements Parser<String[]> {
     @NotNull
     @Override
     public ParserContext<String[]> makeParserContext(final GlobalContext gctx, final int chunkSize) {
-        final Sink<String[]> sink = gctx.sinkFactory.forString();
+        final Sink<String[]> sink = gctx.sinkFactory.forString(gctx.colNum);
         return new ParserContext<>(sink, null, DataType.STRING, new String[chunkSize]);
     }
 

--- a/src/main/java/io/deephaven/csv/parsers/TimestampParserBase.java
+++ b/src/main/java/io/deephaven/csv/parsers/TimestampParserBase.java
@@ -31,7 +31,7 @@ public abstract class TimestampParserBase implements Parser<long[]> {
     @Override
     public ParserContext<long[]> makeParserContext(
             final Parser.GlobalContext gctx, final int chunkSize) {
-        final Sink<long[]> sink = gctx.sinkFactory.forTimestampAsLong();
+        final Sink<long[]> sink = gctx.sinkFactory.forTimestampAsLong(gctx.colNum);
         return new ParserContext<>(sink, null, DataType.TIMESTAMP_AS_LONG, new long[chunkSize]);
     }
 
@@ -49,7 +49,7 @@ public abstract class TimestampParserBase implements Parser<long[]> {
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<long[]> sink = pctx.sink();
-        final Long reservedValue = gctx.sinkFactory.reservedLong();
+        final Long reservedValue = gctx.sinkFactory.reservedTimestampAsLong();
         final long[] values = pctx.valueChunk();
 
         long current = begin;

--- a/src/main/java/io/deephaven/csv/parsers/TimestampParserBase.java
+++ b/src/main/java/io/deephaven/csv/parsers/TimestampParserBase.java
@@ -31,7 +31,7 @@ public abstract class TimestampParserBase implements Parser<long[]> {
     @Override
     public ParserContext<long[]> makeParserContext(
             final Parser.GlobalContext gctx, final int chunkSize) {
-        final Sink<long[]> sink = gctx.sinkFactory.forTimestampAsLong(gctx.colNum);
+        final Sink<long[]> sink = gctx.sinkFactory().forTimestampAsLong(gctx.colNum());
         return new ParserContext<>(sink, null, DataType.TIMESTAMP_AS_LONG, new long[chunkSize]);
     }
 
@@ -45,11 +45,11 @@ public abstract class TimestampParserBase implements Parser<long[]> {
             final boolean appending)
             throws CsvReaderException {
         final MutableLong longHolder = new MutableLong();
-        final Tokenizer t = gctx.tokenizer;
+        final Tokenizer t = gctx.tokenizer();
         final boolean[] nulls = gctx.nullChunk();
 
         final Sink<long[]> sink = pctx.sink();
-        final Long reservedValue = gctx.sinkFactory.reservedTimestampAsLong();
+        final Long reservedValue = gctx.sinkFactory().reservedTimestampAsLong();
         final long[] values = pctx.valueChunk();
 
         long current = begin;
@@ -79,7 +79,7 @@ public abstract class TimestampParserBase implements Parser<long[]> {
                 break;
             }
             if (ih.bs().size() > 1) {
-                gctx.isNullOrWidthOneSoFar = false;
+                gctx.clearIsNullOrWidthOneSoFar();
             }
             values[chunkIndex] = value * scale;
             nulls[chunkIndex] = false;

--- a/src/main/java/io/deephaven/csv/reading/CsvReader.java
+++ b/src/main/java/io/deephaven/csv/reading/CsvReader.java
@@ -126,6 +126,7 @@ public final class CsvReader {
                 final int iiCopy = ii;
                 final Future<ParseDenseStorageToColumn.Result> fcb =
                         exec.submit(wrapError(() -> ParseDenseStorageToColumn.doit(
+                                iiCopy + 1, // 1-based column numbers
                                 dsrs.get(iiCopy).move(),
                                 parsersToUse,
                                 specs,

--- a/src/main/java/io/deephaven/csv/reading/CsvReader.java
+++ b/src/main/java/io/deephaven/csv/reading/CsvReader.java
@@ -126,7 +126,7 @@ public final class CsvReader {
                 final int iiCopy = ii;
                 final Future<ParseDenseStorageToColumn.Result> fcb =
                         exec.submit(wrapError(() -> ParseDenseStorageToColumn.doit(
-                                iiCopy + 1, // 1-based column numbers
+                                iiCopy, // 0-based column numbers
                                 dsrs.get(iiCopy).move(),
                                 parsersToUse,
                                 specs,

--- a/src/main/java/io/deephaven/csv/reading/CsvReader.java
+++ b/src/main/java/io/deephaven/csv/reading/CsvReader.java
@@ -88,7 +88,7 @@ public final class CsvReader {
         final String[][] nullValueLiteralsToUse = new String[numOutputCols][];
         for (int ii = 0; ii < numOutputCols; ++ii) {
             nullValueLiteralsToUse[ii] =
-                    calcNullValueLiteralsToUse(specs, headersToUse[ii], ii + 1).toArray(new String[0]);
+                    calcNullValueLiteralsToUse(specs, headersToUse[ii], ii).toArray(new String[0]);
         }
 
         // Create a DenseStorageWriter for each column. The arrays are sized to "numInputCols" but only populated up to
@@ -114,14 +114,14 @@ public final class CsvReader {
 
         // Start the writer
         final Future<Long> numRowsFuture =
-                exec.submit(wrapError(() -> ParseInputToDenseStorage.doit(firstDataRow, grabber, specs,
+                exec.submit(wrapError(() -> ParseInputToDenseStorage.doit(headersToUse, firstDataRow, grabber, specs,
                         nullValueLiteralsToUse, dsws)));
 
         // Start the readers, taking care to not hold a reference to the DenseStorageReader.
         final ArrayList<Future<ParseDenseStorageToColumn.Result>> sinkFutures = new ArrayList<>();
         try {
             for (int ii = 0; ii < numOutputCols; ++ii) {
-                final List<Parser<?>> parsersToUse = calcParsersToUse(specs, headersToUse[ii], ii + 1);
+                final List<Parser<?>> parsersToUse = calcParsersToUse(specs, headersToUse[ii], ii);
 
                 final int iiCopy = ii;
                 final Future<ParseDenseStorageToColumn.Result> fcb =
@@ -172,13 +172,13 @@ public final class CsvReader {
      * Determine which list of parsers to use for type inference. Returns {@link CsvSpecs#parsers} unless the user has
      * set an override on a column name or column number basis.
      */
-    private static List<Parser<?>> calcParsersToUse(final CsvSpecs specs,
-            final String columnName, final int oneBasedColumnNumber) {
+    private static List<Parser<?>> calcParsersToUse(final CsvSpecs specs, final String columnName,
+            final int columnIndex) {
         Parser<?> specifiedParser = specs.parserForName().get(columnName);
         if (specifiedParser != null) {
             return Collections.singletonList(specifiedParser);
         }
-        specifiedParser = specs.parserForIndex().get(oneBasedColumnNumber);
+        specifiedParser = specs.parserForIndex().get(columnIndex);
         if (specifiedParser != null) {
             return Collections.singletonList(specifiedParser);
         }
@@ -189,13 +189,13 @@ public final class CsvReader {
      * Determine which null value literal to use. Returns {@link CsvSpecs#nullValueLiterals()} unless the user has set
      * an override on a column name or column number basis.
      */
-    private static List<String> calcNullValueLiteralsToUse(final CsvSpecs specs,
-            final String columnName, final int oneBasedColumnNumber) {
+    private static List<String> calcNullValueLiteralsToUse(final CsvSpecs specs, final String columnName,
+            final int columnIndex) {
         List<String> result = specs.nullValueLiteralsForName().get(columnName);
         if (result != null) {
             return result;
         }
-        result = specs.nullValueLiteralsForIndex().get(oneBasedColumnNumber);
+        result = specs.nullValueLiteralsForIndex().get(columnIndex);
         if (result != null) {
             return result;
         }
@@ -225,8 +225,7 @@ public final class CsvReader {
         }
 
         // If we still have nothing, try generate synthetic column headers (works only if the file is
-        // non-empty,
-        // because we need to infer the column count).
+        // non-empty, because we need to infer the column count).
         final byte[][] firstDataRow;
         if (headersToUse == null) {
             firstDataRow = tryReadOneRow(grabber);
@@ -244,7 +243,7 @@ public final class CsvReader {
 
         // Apply column specific overrides.
         for (Map.Entry<Integer, String> entry : specs.headerForIndex().entrySet()) {
-            headersToUse[entry.getKey() - 1] = entry.getValue();
+            headersToUse[entry.getKey()] = entry.getValue();
         }
 
         firstDataRowHolder.setValue(firstDataRow);

--- a/src/main/java/io/deephaven/csv/reading/ParseDenseStorageToColumn.java
+++ b/src/main/java/io/deephaven/csv/reading/ParseDenseStorageToColumn.java
@@ -28,7 +28,8 @@ public final class ParseDenseStorageToColumn {
      *         data.
      */
     public static Result doit(
-            Moveable<DenseStorageReader> dsr,
+            final int colNum,
+            final Moveable<DenseStorageReader> dsr,
             final List<Parser<?>> parsers,
             final CsvSpecs specs,
             final String[] nullValueLiteralsToUse,
@@ -38,7 +39,7 @@ public final class ParseDenseStorageToColumn {
 
         final Tokenizer tokenizer = new Tokenizer(specs.customDoubleParser(), specs.customTimeZoneParser());
         final Parser.GlobalContext gctx =
-                new Parser.GlobalContext(tokenizer, sinkFactory, nullValueLiteralsToUse);
+                new Parser.GlobalContext(colNum, tokenizer, sinkFactory, nullValueLiteralsToUse);
 
         // Make an IteratorHolder for the first pass over the input. Make a copy of the DenseStorageReader in case
         // we need to do a second pass. We take care to not hold these references longer than necessary, to give the

--- a/src/main/java/io/deephaven/csv/sinks/ArraySinkFactory.java
+++ b/src/main/java/io/deephaven/csv/sinks/ArraySinkFactory.java
@@ -35,7 +35,7 @@ public class ArraySinkFactory implements SinkFactory {
     }
 
     @Override
-    public Sink<byte[]> forByte(MutableObject<Source<byte[]>> source) {
+    public Sink<byte[]> forByte(final int colNum, final MutableObject<Source<byte[]>> source) {
         final ArrayByteSink result = new ArrayByteSink(byteSentinel);
         source.setValue(result);
         return result;
@@ -47,7 +47,7 @@ public class ArraySinkFactory implements SinkFactory {
     }
 
     @Override
-    public Sink<short[]> forShort(MutableObject<Source<short[]>> source) {
+    public Sink<short[]> forShort(final int colNum, final MutableObject<Source<short[]>> source) {
         final ArrayShortSink result = new ArrayShortSink(shortSentinel);
         source.setValue(result);
         return result;
@@ -59,7 +59,7 @@ public class ArraySinkFactory implements SinkFactory {
     }
 
     @Override
-    public Sink<int[]> forInt(MutableObject<Source<int[]>> source) {
+    public Sink<int[]> forInt(final int colNum, final MutableObject<Source<int[]>> source) {
         final ArrayIntSink result = new ArrayIntSink(intSentinel);
         source.setValue(result);
         return result;
@@ -71,7 +71,7 @@ public class ArraySinkFactory implements SinkFactory {
     }
 
     @Override
-    public Sink<long[]> forLong(MutableObject<Source<long[]>> source) {
+    public Sink<long[]> forLong(final int colNum, final MutableObject<Source<long[]>> source) {
         final ArrayLongSink result = new ArrayLongSink(longSentinel);
         source.setValue(result);
         return result;
@@ -83,7 +83,7 @@ public class ArraySinkFactory implements SinkFactory {
     }
 
     @Override
-    public Sink<float[]> forFloat() {
+    public Sink<float[]> forFloat(final int colNum) {
         return new ArrayFloatSink(floatSentinel);
     }
 
@@ -93,7 +93,7 @@ public class ArraySinkFactory implements SinkFactory {
     }
 
     @Override
-    public Sink<double[]> forDouble() {
+    public Sink<double[]> forDouble(final int colNum) {
         return new ArrayDoubleSink(doubleSentinel);
     }
 
@@ -103,12 +103,12 @@ public class ArraySinkFactory implements SinkFactory {
     }
 
     @Override
-    public Sink<byte[]> forBooleanAsByte() {
+    public Sink<byte[]> forBooleanAsByte(final int colNum) {
         return new ArrayBooleanAsByteSink(booleanAsByteSentinel);
     }
 
     @Override
-    public Sink<char[]> forChar() {
+    public Sink<char[]> forChar(final int colNum) {
         return new ArrayCharSink(charSentinel);
     }
 
@@ -118,7 +118,7 @@ public class ArraySinkFactory implements SinkFactory {
     }
 
     @Override
-    public Sink<String[]> forString() {
+    public Sink<String[]> forString(final int colNum) {
         return new ArrayStringSink(stringSentinel);
     }
 
@@ -128,7 +128,7 @@ public class ArraySinkFactory implements SinkFactory {
     }
 
     @Override
-    public Sink<long[]> forDateTimeAsLong() {
+    public Sink<long[]> forDateTimeAsLong(final int colNum) {
         return new ArrayDateTimeAsLongSink(dateTimeAsLongSentinel);
     }
 
@@ -138,7 +138,7 @@ public class ArraySinkFactory implements SinkFactory {
     }
 
     @Override
-    public Sink<long[]> forTimestampAsLong() {
+    public Sink<long[]> forTimestampAsLong(final int colNum) {
         return new ArrayTimestampAsLongSink(timestampAsLongSentinel);
     }
 

--- a/src/main/java/io/deephaven/csv/sinks/SinkFactory.java
+++ b/src/main/java/io/deephaven/csv/sinks/SinkFactory.java
@@ -2,7 +2,7 @@ package io.deephaven.csv.sinks;
 
 import io.deephaven.csv.util.MutableObject;
 
-import java.util.function.Supplier;
+import java.util.function.IntFunction;
 
 /**
  * An interface which allows the CsvReader to write to column data structures whose details it is unaware of. Using this
@@ -44,17 +44,17 @@ public interface SinkFactory {
      * of protection.
      */
     static <TBYTESINK extends Sink<byte[]> & Source<byte[]>, TSHORTSINK extends Sink<short[]> & Source<short[]>, TINTSINK extends Sink<int[]> & Source<int[]>, TLONGSINK extends Sink<long[]> & Source<long[]>, TFLOATSINK extends Sink<float[]>, TDOUBLESINK extends Sink<double[]>, TBOOLASBYTESINK extends Sink<byte[]>, TCHARSINK extends Sink<char[]>, TSTRINGSINK extends Sink<String[]>, TDATETIMEASLONGSINK extends Sink<long[]>, TTIMESTAMPASLONGSINK extends Sink<long[]>> SinkFactory of(
-            Supplier<TBYTESINK> byteSinkSupplier,
-            Supplier<TSHORTSINK> shortSinkSupplier,
-            Supplier<TINTSINK> intSinkSupplier,
-            Supplier<TLONGSINK> longSinkSupplier,
-            Supplier<TFLOATSINK> floatSinkSupplier,
-            Supplier<TDOUBLESINK> doubleSinkSupplier,
-            Supplier<TBOOLASBYTESINK> booleanAsByteSinkSupplier, // no Byte reservedBooleanAsByte,
-            Supplier<TCHARSINK> charSinkSupplier,
-            Supplier<TSTRINGSINK> stringSinkSupplier,
-            Supplier<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier,
-            Supplier<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier) {
+            IntFunction<TBYTESINK> byteSinkSupplier,
+            IntFunction<TSHORTSINK> shortSinkSupplier,
+            IntFunction<TINTSINK> intSinkSupplier,
+            IntFunction<TLONGSINK> longSinkSupplier,
+            IntFunction<TFLOATSINK> floatSinkSupplier,
+            IntFunction<TDOUBLESINK> doubleSinkSupplier,
+            IntFunction<TBOOLASBYTESINK> booleanAsByteSinkSupplier,
+            IntFunction<TCHARSINK> charSinkSupplier,
+            IntFunction<TSTRINGSINK> stringSinkSupplier,
+            IntFunction<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier,
+            IntFunction<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier) {
         return new SinkFactoryImpl<>(byteSinkSupplier, null,
                 shortSinkSupplier, null,
                 intSinkSupplier, null,
@@ -73,26 +73,27 @@ public interface SinkFactory {
      * from their corresponding type.
      */
     static <TBYTESINK extends Sink<byte[]> & Source<byte[]>, TSHORTSINK extends Sink<short[]> & Source<short[]>, TINTSINK extends Sink<int[]> & Source<int[]>, TLONGSINK extends Sink<long[]> & Source<long[]>, TFLOATSINK extends Sink<float[]>, TDOUBLESINK extends Sink<double[]>, TBOOLASBYTESINK extends Sink<byte[]>, TCHARSINK extends Sink<char[]>, TSTRINGSINK extends Sink<String[]>, TDATETIMEASLONGSINK extends Sink<long[]>, TTIMESTAMPASLONGSINK extends Sink<long[]>> SinkFactory of(
-            Supplier<TBYTESINK> byteSinkSupplier,
+            IntFunction<TBYTESINK> byteSinkSupplier,
             Byte reservedByte,
-            Supplier<TSHORTSINK> shortSinkSupplier,
+            IntFunction<TSHORTSINK> shortSinkSupplier,
             Short reservedShort,
-            Supplier<TINTSINK> intSinkSupplier,
+            IntFunction<TINTSINK> intSinkSupplier,
             Integer reservedInt,
-            Supplier<TLONGSINK> longSinkSupplier,
+            IntFunction<TLONGSINK> longSinkSupplier,
             Long reservedLong,
-            Supplier<TFLOATSINK> floatSinkSupplier,
+            IntFunction<TFLOATSINK> floatSinkSupplier,
             Float reservedFloat,
-            Supplier<TDOUBLESINK> doubleSinkSupplier,
+            IntFunction<TDOUBLESINK> doubleSinkSupplier,
             Double reservedDouble,
-            Supplier<TBOOLASBYTESINK> booleanAsByteSinkSupplier, // no Byte reservedBooleanAsByte,
-            Supplier<TCHARSINK> charSinkSupplier,
+            IntFunction<TBOOLASBYTESINK> booleanAsByteSinkSupplier,
+            // no Byte reservedBooleanAsByte,
+            IntFunction<TCHARSINK> charSinkSupplier,
             Character reservedChar,
-            Supplier<TSTRINGSINK> stringSinkSupplier,
+            IntFunction<TSTRINGSINK> stringSinkSupplier,
             String reservedString,
-            Supplier<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier,
+            IntFunction<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier,
             Long reservedDateTimeAsLong,
-            Supplier<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier,
+            IntFunction<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier,
             Long reservedTimestampAsLong) {
         return new SinkFactoryImpl<>(byteSinkSupplier, reservedByte,
                 shortSinkSupplier, reservedShort,
@@ -108,28 +109,28 @@ public interface SinkFactory {
     }
 
     /**
-     * This factory method creates a {@link SinkFactory} from the corresponding lambdas. This version second version has
-     * somewhat less peformant type inference, because it does not allow wider numeric parsers (like double) to directly
-     * read back data written by narrower numeric parsers (like short). Instead the wider parser needs to reparse the
-     * ASCII text. If the factory implementor prefers the more performant version, the caller can invoke
-     * {@link SinkFactory#of} instead.
+     * This factory method creates a {@link SinkFactory} from the corresponding lambdas. This version has somewhat less
+     * peformant type inference, because it does not allow wider numeric parsers (like double) to directly read back
+     * data written by narrower numeric parsers (like short). Instead the wider parser needs to reparse the ASCII text.
+     * If the factory implementor prefers the more performant version, the caller can invoke {@link SinkFactory#of}
+     * instead.
      *
      * As a service to the caller, we also make the provided {@link SinkFactory} threadsafe by synchronizing all the
      * forXXX methods. This is probably not necessary for most suppliers but we do it in order to provide an extra level
      * of protection.
      */
     static <TBYTESINK extends Sink<byte[]>, TSHORTSINK extends Sink<short[]>, TINTSINK extends Sink<int[]>, TLONGSINK extends Sink<long[]>, TFLOATSINK extends Sink<float[]>, TDOUBLESINK extends Sink<double[]>, TBOOLASBYTESINK extends Sink<byte[]>, TCHARSINK extends Sink<char[]>, TSTRINGSINK extends Sink<String[]>, TDATETIMEASLONGSINK extends Sink<long[]>, TTIMESTAMPASLONGSINK extends Sink<long[]>> SinkFactory ofSimple(
-            Supplier<TBYTESINK> byteSinkSupplier,
-            Supplier<TSHORTSINK> shortSinkSupplier,
-            Supplier<TINTSINK> intSinkSupplier,
-            Supplier<TLONGSINK> longSinkSupplier,
-            Supplier<TFLOATSINK> floatSinkSupplier,
-            Supplier<TDOUBLESINK> doubleSinkSupplier,
-            Supplier<TBOOLASBYTESINK> booleanAsByteSinkSupplier, // no Byte reservedBooleanAsByte,
-            Supplier<TCHARSINK> charSinkSupplier,
-            Supplier<TSTRINGSINK> stringSinkSupplier,
-            Supplier<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier,
-            Supplier<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier) {
+            IntFunction<TBYTESINK> byteSinkSupplier,
+            IntFunction<TSHORTSINK> shortSinkSupplier,
+            IntFunction<TINTSINK> intSinkSupplier,
+            IntFunction<TLONGSINK> longSinkSupplier,
+            IntFunction<TFLOATSINK> floatSinkSupplier,
+            IntFunction<TDOUBLESINK> doubleSinkSupplier,
+            IntFunction<TBOOLASBYTESINK> booleanAsByteSinkSupplier,
+            IntFunction<TCHARSINK> charSinkSupplier,
+            IntFunction<TSTRINGSINK> stringSinkSupplier,
+            IntFunction<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier,
+            IntFunction<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier) {
         return new SinkFactorySimpleImpl<>(byteSinkSupplier, null,
                 shortSinkSupplier, null,
                 intSinkSupplier, null,
@@ -148,26 +149,27 @@ public interface SinkFactory {
      * from their corresponding type.
      */
     static <TBYTESINK extends Sink<byte[]>, TSHORTSINK extends Sink<short[]>, TINTSINK extends Sink<int[]>, TLONGSINK extends Sink<long[]>, TFLOATSINK extends Sink<float[]>, TDOUBLESINK extends Sink<double[]>, TBOOLASBYTESINK extends Sink<byte[]>, TCHARSINK extends Sink<char[]>, TSTRINGSINK extends Sink<String[]>, TDATETIMEASLONGSINK extends Sink<long[]>, TTIMESTAMPASLONGSINK extends Sink<long[]>> SinkFactory ofSimple(
-            Supplier<TBYTESINK> byteSinkSupplier,
+            IntFunction<TBYTESINK> byteSinkSupplier,
             Byte reservedByte,
-            Supplier<TSHORTSINK> shortSinkSupplier,
+            IntFunction<TSHORTSINK> shortSinkSupplier,
             Short reservedShort,
-            Supplier<TINTSINK> intSinkSupplier,
+            IntFunction<TINTSINK> intSinkSupplier,
             Integer reservedInt,
-            Supplier<TLONGSINK> longSinkSupplier,
+            IntFunction<TLONGSINK> longSinkSupplier,
             Long reservedLong,
-            Supplier<TFLOATSINK> floatSinkSupplier,
+            IntFunction<TFLOATSINK> floatSinkSupplier,
             Float reservedFloat,
-            Supplier<TDOUBLESINK> doubleSinkSupplier,
+            IntFunction<TDOUBLESINK> doubleSinkSupplier,
             Double reservedDouble,
-            Supplier<TBOOLASBYTESINK> booleanAsByteSinkSupplier, // no Byte reservedBooleanAsByte,
-            Supplier<TCHARSINK> charSinkSupplier,
+            IntFunction<TBOOLASBYTESINK> booleanAsByteSinkSupplier,
+            // no Byte reservedBooleanAsByte,
+            IntFunction<TCHARSINK> charSinkSupplier,
             Character reservedChar,
-            Supplier<TSTRINGSINK> stringSinkSupplier,
+            IntFunction<TSTRINGSINK> stringSinkSupplier,
             String reservedString,
-            Supplier<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier,
+            IntFunction<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier,
             Long reservedDateTimeAsLong,
-            Supplier<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier,
+            IntFunction<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier,
             Long reservedTimestampAsLong) {
         return new SinkFactorySimpleImpl<>(byteSinkSupplier, reservedByte,
                 shortSinkSupplier, reservedShort,
@@ -216,67 +218,115 @@ public interface SinkFactory {
     }
 
 
-    /** Provide a Sink and a Source for the byte representation. */
-    Sink<byte[]> forByte(MutableObject<Source<byte[]>> source);
+    /**
+     * Provide a Sink and optional Source for the byte representation.
+     * 
+     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param source The optional Source that can be used to read back the data for faster type inference.
+     **/
+    Sink<byte[]> forByte(int colNum, MutableObject<Source<byte[]>> source);
 
     /** The optional reserved value for the byte representation. */
     Byte reservedByte();
 
-    /** Provide a Sink and a Source for the short representation. */
-    Sink<short[]> forShort(MutableObject<Source<short[]>> source);
+    /**
+     * Provide a Sink and optional Source for the short representation.
+     * 
+     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param source The optional Source that can be used to read back the data for faster type inference.
+     **/
+    Sink<short[]> forShort(int colNum, MutableObject<Source<short[]>> source);
 
     /** The optional reserved value for the short representation. */
     Short reservedShort();
 
-    /** Provide a Sink and a Source for the int representation. */
-    Sink<int[]> forInt(MutableObject<Source<int[]>> source);
+    /**
+     * Provide a Sink and optional Source for the int representation.
+     * 
+     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param source The optional Source that can be used to read back the data for faster type inference.
+     **/
+    Sink<int[]> forInt(int colNum, MutableObject<Source<int[]>> source);
 
     /** The optional reserved value for the int representation. */
     Integer reservedInt();
 
-    /** Provide a Sink and a Source for the long representation. */
-    Sink<long[]> forLong(MutableObject<Source<long[]>> source);
+    /**
+     * Provide a Sink and optional Source for the long representation.
+     * 
+     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param source The optional Source that can be used to read back the data for faster type inference.
+     **/
+    Sink<long[]> forLong(int colNum, MutableObject<Source<long[]>> source);
 
     /** The optional reserved value for the long representation. */
     Long reservedLong();
 
-    /** Provide a Sink for the float representation. */
-    Sink<float[]> forFloat();
+    /**
+     * Provide a Sink for the float representation.
+     * 
+     * @param colNum The (one-based) column number that this Sink will be used for.
+     **/
+    Sink<float[]> forFloat(int colNum);
 
     /** The optional reserved value for the float representation. */
     Float reservedFloat();
 
-    /** Provide a Sink for the double representation. */
-    Sink<double[]> forDouble();
+    /**
+     * Provide a Sink for the double representation.
+     * 
+     * @param colNum The (one-based) column number that this Sink will be used for.
+     **/
+    Sink<double[]> forDouble(int colNum);
 
     /** The optional reserved value for the double representation. */
     Double reservedDouble();
 
-    /** Provide a Sink for the boolean (as byte) representation. */
-    Sink<byte[]> forBooleanAsByte();
+    /**
+     * Provide a Sink for the booelan as byte representation.
+     * 
+     * @param colNum The (one-based) column number that this Sink will be used for.
+     **/
+    Sink<byte[]> forBooleanAsByte(int colNum);
 
     // there is no reserved value for the boolean as byte representation, as none is needed.
 
-    /** Provide a Sink for the char representation. */
-    Sink<char[]> forChar();
+    /**
+     * Provide a Sink for the char representation.
+     * 
+     * @param colNum The (one-based) column number that this Sink will be used for.
+     **/
+    Sink<char[]> forChar(int colNum);
 
     /** The optional reserved value for the char representation. */
     Character reservedChar();
 
-    /** Provide a Sink for the String representation. */
-    Sink<String[]> forString();
+    /**
+     * Provide a Sink for the String representation.
+     * 
+     * @param colNum The (one-based) column number that this Sink will be used for.
+     **/
+    Sink<String[]> forString(int colNum);
 
     /** The optional reserved value for the String representation. */
     String reservedString();
 
-    /** Provide a Sink for the DateTime (as long) representation. */
-    Sink<long[]> forDateTimeAsLong();
+    /**
+     * Provide a Sink for the datetime as long representation.
+     * 
+     * @param colNum The (one-based) column number that this Sink will be used for.
+     **/
+    Sink<long[]> forDateTimeAsLong(int colNum);
 
     /** The optional reserved value for the DateTime (as long) representation. */
     Long reservedDateTimeAsLong();
 
-    /** Provide a Sink for the Timestamp (as long) representation. */
-    Sink<long[]> forTimestampAsLong();
+    /**
+     * Provide a Sink for the Timestamp (as long) representation.
+     * 
+     * @param colNum The (one-based) column number that this Sink will be used for.
+     **/
+    Sink<long[]> forTimestampAsLong(int colNum);
 
     /** The optional reserved value for the Timestamp (as long) representation. */
     Long reservedTimestampAsLong();
@@ -289,27 +339,28 @@ abstract class SinkFactoryImplBase<TFLOATSINK extends Sink<float[]>, TDOUBLESINK
     private final Short reservedShort;
     private final Integer reservedInt;
     private final Long reservedLong;
-    private final Supplier<TFLOATSINK> floatSinkSupplier;
+    private final IntFunction<TFLOATSINK> floatSinkSupplier;
     private final Float reservedFloat;
-    private final Supplier<TDOUBLESINK> doubleSinkSupplier;
+    private final IntFunction<TDOUBLESINK> doubleSinkSupplier;
     private final Double reservedDouble;
-    private final Supplier<TBOOLASBYTESINK> booleanAsByteSinkSupplier; // no Byte reservedBooleanAsByte,
-    private final Supplier<TCHARSINK> charSinkSupplier;
+    private final IntFunction<TBOOLASBYTESINK> booleanAsByteSinkSupplier; // no Byte reservedBooleanAsByte,
+    private final IntFunction<TCHARSINK> charSinkSupplier;
     private final Character reservedChar;
-    private final Supplier<TSTRINGSINK> stringSinkSupplier;
+    private final IntFunction<TSTRINGSINK> stringSinkSupplier;
     private final String reservedString;
-    private final Supplier<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier;
+    private final IntFunction<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier;
     private final Long reservedDateTimeAsLong;
-    private final Supplier<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier;
+    private final IntFunction<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier;
     private final Long reservedTimestampAsLong;
 
     protected SinkFactoryImplBase(Byte reservedByte, Short reservedShort, Integer reservedInt, Long reservedLong,
-            Supplier<TFLOATSINK> floatSinkSupplier, Float reservedFloat, Supplier<TDOUBLESINK> doubleSinkSupplier,
-            Double reservedDouble, Supplier<TBOOLASBYTESINK> booleanAsByteSinkSupplier,
-            Supplier<TCHARSINK> charSinkSupplier, Character reservedChar, Supplier<TSTRINGSINK> stringSinkSupplier,
-            String reservedString, Supplier<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier,
-            Long reservedDateTimeAsLong, Supplier<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier,
-            Long reservedTimestampAsLong) {
+            IntFunction<TFLOATSINK> floatSinkSupplier, Float reservedFloat,
+            IntFunction<TDOUBLESINK> doubleSinkSupplier, Double reservedDouble,
+            IntFunction<TBOOLASBYTESINK> booleanAsByteSinkSupplier,
+            IntFunction<TCHARSINK> charSinkSupplier, Character reservedChar,
+            IntFunction<TSTRINGSINK> stringSinkSupplier, String reservedString,
+            IntFunction<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier, Long reservedDateTimeAsLong,
+            IntFunction<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier, Long reservedTimestampAsLong) {
         this.reservedByte = reservedByte;
         this.reservedShort = reservedShort;
         this.reservedInt = reservedInt;
@@ -350,8 +401,8 @@ abstract class SinkFactoryImplBase<TFLOATSINK extends Sink<float[]>, TDOUBLESINK
     }
 
     @Override
-    public synchronized final Sink<float[]> forFloat() {
-        return floatSinkSupplier.get();
+    public synchronized final Sink<float[]> forFloat(final int colNum) {
+        return floatSinkSupplier.apply(colNum);
     }
 
     @Override
@@ -360,8 +411,8 @@ abstract class SinkFactoryImplBase<TFLOATSINK extends Sink<float[]>, TDOUBLESINK
     }
 
     @Override
-    public synchronized final Sink<double[]> forDouble() {
-        return doubleSinkSupplier.get();
+    public synchronized final Sink<double[]> forDouble(final int colNum) {
+        return doubleSinkSupplier.apply(colNum);
     }
 
     @Override
@@ -370,13 +421,13 @@ abstract class SinkFactoryImplBase<TFLOATSINK extends Sink<float[]>, TDOUBLESINK
     }
 
     @Override
-    public synchronized final Sink<byte[]> forBooleanAsByte() {
-        return booleanAsByteSinkSupplier.get();
+    public synchronized final Sink<byte[]> forBooleanAsByte(final int colNum) {
+        return booleanAsByteSinkSupplier.apply(colNum);
     }
 
     @Override
-    public synchronized final Sink<char[]> forChar() {
-        return charSinkSupplier.get();
+    public synchronized final Sink<char[]> forChar(final int colNum) {
+        return charSinkSupplier.apply(colNum);
     }
 
     @Override
@@ -385,8 +436,8 @@ abstract class SinkFactoryImplBase<TFLOATSINK extends Sink<float[]>, TDOUBLESINK
     }
 
     @Override
-    public synchronized final Sink<String[]> forString() {
-        return stringSinkSupplier.get();
+    public synchronized final Sink<String[]> forString(final int colNum) {
+        return stringSinkSupplier.apply(colNum);
     }
 
     @Override
@@ -395,8 +446,8 @@ abstract class SinkFactoryImplBase<TFLOATSINK extends Sink<float[]>, TDOUBLESINK
     }
 
     @Override
-    public synchronized final Sink<long[]> forDateTimeAsLong() {
-        return dateTimeAsLongSinkSupplier.get();
+    public synchronized final Sink<long[]> forDateTimeAsLong(final int colNum) {
+        return dateTimeAsLongSinkSupplier.apply(colNum);
     }
 
     @Override
@@ -405,8 +456,8 @@ abstract class SinkFactoryImplBase<TFLOATSINK extends Sink<float[]>, TDOUBLESINK
     }
 
     @Override
-    public synchronized final Sink<long[]> forTimestampAsLong() {
-        return timestampAsLongSinkSupplier.get();
+    public synchronized final Sink<long[]> forTimestampAsLong(final int colNum) {
+        return timestampAsLongSinkSupplier.apply(colNum);
     }
 
     @Override
@@ -419,26 +470,23 @@ abstract class SinkFactoryImplBase<TFLOATSINK extends Sink<float[]>, TDOUBLESINK
 final class SinkFactoryImpl<TBYTESINK extends Sink<byte[]> & Source<byte[]>, TSHORTSINK extends Sink<short[]> & Source<short[]>, TINTSINK extends Sink<int[]> & Source<int[]>, TLONGSINK extends Sink<long[]> & Source<long[]>, TFLOATSINK extends Sink<float[]>, TDOUBLESINK extends Sink<double[]>, TBOOLASBYTESINK extends Sink<byte[]>, TCHARSINK extends Sink<char[]>, TSTRINGSINK extends Sink<String[]>, TDATETIMEASLONGSINK extends Sink<long[]>, TTIMESTAMPASLONGSINK extends Sink<long[]>>
         extends
         SinkFactoryImplBase<TFLOATSINK, TDOUBLESINK, TBOOLASBYTESINK, TCHARSINK, TSTRINGSINK, TDATETIMEASLONGSINK, TTIMESTAMPASLONGSINK> {
-    private final Supplier<TBYTESINK> byteSinkSupplier;
-    private final Supplier<TSHORTSINK> shortSinkSupplier;
-    private final Supplier<TINTSINK> intSinkSupplier;
-    private final Supplier<TLONGSINK> longSinkSupplier;
+    private final IntFunction<TBYTESINK> byteSinkSupplier;
+    private final IntFunction<TSHORTSINK> shortSinkSupplier;
+    private final IntFunction<TINTSINK> intSinkSupplier;
+    private final IntFunction<TLONGSINK> longSinkSupplier;
 
     public SinkFactoryImpl(
-            Supplier<TBYTESINK> byteSinkSupplier,
-            Byte reservedByte,
-            Supplier<TSHORTSINK> shortSinkSupplier,
-            Short reservedShort,
-            Supplier<TINTSINK> intSinkSupplier,
-            Integer reservedInt,
-            Supplier<TLONGSINK> longSinkSupplier,
-            Long reservedLong,
-            Supplier<TFLOATSINK> floatSinkSupplier, Float reservedFloat, Supplier<TDOUBLESINK> doubleSinkSupplier,
-            Double reservedDouble, Supplier<TBOOLASBYTESINK> booleanAsByteSinkSupplier,
-            Supplier<TCHARSINK> charSinkSupplier, Character reservedChar, Supplier<TSTRINGSINK> stringSinkSupplier,
-            String reservedString, Supplier<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier,
-            Long reservedDateTimeAsLong, Supplier<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier,
-            Long reservedTimestampAsLong) {
+            IntFunction<TBYTESINK> byteSinkSupplier, Byte reservedByte,
+            IntFunction<TSHORTSINK> shortSinkSupplier, Short reservedShort,
+            IntFunction<TINTSINK> intSinkSupplier, Integer reservedInt,
+            IntFunction<TLONGSINK> longSinkSupplier, Long reservedLong,
+            IntFunction<TFLOATSINK> floatSinkSupplier, Float reservedFloat,
+            IntFunction<TDOUBLESINK> doubleSinkSupplier, Double reservedDouble,
+            IntFunction<TBOOLASBYTESINK> booleanAsByteSinkSupplier,
+            IntFunction<TCHARSINK> charSinkSupplier, Character reservedChar,
+            IntFunction<TSTRINGSINK> stringSinkSupplier, String reservedString,
+            IntFunction<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier, Long reservedDateTimeAsLong,
+            IntFunction<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier, Long reservedTimestampAsLong) {
         super(reservedByte, reservedShort, reservedInt, reservedLong, floatSinkSupplier, reservedFloat,
                 doubleSinkSupplier, reservedDouble, booleanAsByteSinkSupplier, charSinkSupplier, reservedChar,
                 stringSinkSupplier, reservedString, dateTimeAsLongSinkSupplier, reservedDateTimeAsLong,
@@ -450,29 +498,29 @@ final class SinkFactoryImpl<TBYTESINK extends Sink<byte[]> & Source<byte[]>, TSH
     }
 
     @Override
-    public synchronized Sink<byte[]> forByte(MutableObject<Source<byte[]>> source) {
-        final TBYTESINK result = byteSinkSupplier.get();
+    public synchronized Sink<byte[]> forByte(final int colNum, final MutableObject<Source<byte[]>> source) {
+        final TBYTESINK result = byteSinkSupplier.apply(colNum);
         source.setValue(result);
         return result;
     }
 
     @Override
-    public synchronized Sink<short[]> forShort(MutableObject<Source<short[]>> source) {
-        final TSHORTSINK result = shortSinkSupplier.get();
+    public synchronized Sink<short[]> forShort(final int colNum, MutableObject<Source<short[]>> source) {
+        final TSHORTSINK result = shortSinkSupplier.apply(colNum);
         source.setValue(result);
         return result;
     }
 
     @Override
-    public synchronized Sink<int[]> forInt(MutableObject<Source<int[]>> source) {
-        final TINTSINK result = intSinkSupplier.get();
+    public synchronized Sink<int[]> forInt(final int colNum, MutableObject<Source<int[]>> source) {
+        final TINTSINK result = intSinkSupplier.apply(colNum);
         source.setValue(result);
         return result;
     }
 
     @Override
-    public synchronized Sink<long[]> forLong(MutableObject<Source<long[]>> source) {
-        final TLONGSINK result = longSinkSupplier.get();
+    public synchronized Sink<long[]> forLong(final int colNum, MutableObject<Source<long[]>> source) {
+        final TLONGSINK result = longSinkSupplier.apply(colNum);
         source.setValue(result);
         return result;
     }
@@ -482,26 +530,23 @@ final class SinkFactoryImpl<TBYTESINK extends Sink<byte[]> & Source<byte[]>, TSH
 final class SinkFactorySimpleImpl<TBYTESINK extends Sink<byte[]>, TSHORTSINK extends Sink<short[]>, TINTSINK extends Sink<int[]>, TLONGSINK extends Sink<long[]>, TFLOATSINK extends Sink<float[]>, TDOUBLESINK extends Sink<double[]>, TBOOLASBYTESINK extends Sink<byte[]>, TCHARSINK extends Sink<char[]>, TSTRINGSINK extends Sink<String[]>, TDATETIMEASLONGSINK extends Sink<long[]>, TTIMESTAMPASLONGSINK extends Sink<long[]>>
         extends
         SinkFactoryImplBase<TFLOATSINK, TDOUBLESINK, TBOOLASBYTESINK, TCHARSINK, TSTRINGSINK, TDATETIMEASLONGSINK, TTIMESTAMPASLONGSINK> {
-    private final Supplier<TBYTESINK> byteSinkSupplier;
-    private final Supplier<TSHORTSINK> shortSinkSupplier;
-    private final Supplier<TINTSINK> intSinkSupplier;
-    private final Supplier<TLONGSINK> longSinkSupplier;
+    private final IntFunction<TBYTESINK> byteSinkSupplier;
+    private final IntFunction<TSHORTSINK> shortSinkSupplier;
+    private final IntFunction<TINTSINK> intSinkSupplier;
+    private final IntFunction<TLONGSINK> longSinkSupplier;
 
     public SinkFactorySimpleImpl(
-            Supplier<TBYTESINK> byteSinkSupplier,
-            Byte reservedByte,
-            Supplier<TSHORTSINK> shortSinkSupplier,
-            Short reservedShort,
-            Supplier<TINTSINK> intSinkSupplier,
-            Integer reservedInt,
-            Supplier<TLONGSINK> longSinkSupplier,
-            Long reservedLong,
-            Supplier<TFLOATSINK> floatSinkSupplier, Float reservedFloat, Supplier<TDOUBLESINK> doubleSinkSupplier,
-            Double reservedDouble, Supplier<TBOOLASBYTESINK> booleanAsByteSinkSupplier,
-            Supplier<TCHARSINK> charSinkSupplier, Character reservedChar, Supplier<TSTRINGSINK> stringSinkSupplier,
-            String reservedString, Supplier<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier,
-            Long reservedDateTimeAsLong, Supplier<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier,
-            Long reservedTimestampAsLong) {
+            IntFunction<TBYTESINK> byteSinkSupplier, Byte reservedByte,
+            IntFunction<TSHORTSINK> shortSinkSupplier, Short reservedShort,
+            IntFunction<TINTSINK> intSinkSupplier, Integer reservedInt,
+            IntFunction<TLONGSINK> longSinkSupplier, Long reservedLong,
+            IntFunction<TFLOATSINK> floatSinkSupplier, Float reservedFloat,
+            IntFunction<TDOUBLESINK> doubleSinkSupplier, Double reservedDouble,
+            IntFunction<TBOOLASBYTESINK> booleanAsByteSinkSupplier,
+            IntFunction<TCHARSINK> charSinkSupplier, Character reservedChar,
+            IntFunction<TSTRINGSINK> stringSinkSupplier, String reservedString,
+            IntFunction<TDATETIMEASLONGSINK> dateTimeAsLongSinkSupplier, Long reservedDateTimeAsLong,
+            IntFunction<TTIMESTAMPASLONGSINK> timestampAsLongSinkSupplier, Long reservedTimestampAsLong) {
         super(reservedByte, reservedShort, reservedInt, reservedLong, floatSinkSupplier, reservedFloat,
                 doubleSinkSupplier, reservedDouble, booleanAsByteSinkSupplier, charSinkSupplier, reservedChar,
                 stringSinkSupplier, reservedString, dateTimeAsLongSinkSupplier, reservedDateTimeAsLong,
@@ -513,26 +558,26 @@ final class SinkFactorySimpleImpl<TBYTESINK extends Sink<byte[]>, TSHORTSINK ext
     }
 
     @Override
-    public synchronized Sink<byte[]> forByte(MutableObject<Source<byte[]>> source) {
+    public synchronized Sink<byte[]> forByte(final int colNum, final MutableObject<Source<byte[]>> source) {
         source.setValue(null);
-        return byteSinkSupplier.get();
+        return byteSinkSupplier.apply(colNum);
     }
 
     @Override
-    public synchronized Sink<short[]> forShort(MutableObject<Source<short[]>> source) {
+    public synchronized Sink<short[]> forShort(final int colNum, MutableObject<Source<short[]>> source) {
         source.setValue(null);
-        return shortSinkSupplier.get();
+        return shortSinkSupplier.apply(colNum);
     }
 
     @Override
-    public synchronized Sink<int[]> forInt(MutableObject<Source<int[]>> source) {
+    public synchronized Sink<int[]> forInt(final int colNum, MutableObject<Source<int[]>> source) {
         source.setValue(null);
-        return intSinkSupplier.get();
+        return intSinkSupplier.apply(colNum);
     }
 
     @Override
-    public synchronized Sink<long[]> forLong(MutableObject<Source<long[]>> source) {
+    public synchronized Sink<long[]> forLong(final int colNum, MutableObject<Source<long[]>> source) {
         source.setValue(null);
-        return longSinkSupplier.get();
+        return longSinkSupplier.apply(colNum);
     }
 }

--- a/src/main/java/io/deephaven/csv/sinks/SinkFactory.java
+++ b/src/main/java/io/deephaven/csv/sinks/SinkFactory.java
@@ -221,7 +221,7 @@ public interface SinkFactory {
     /**
      * Provide a Sink and optional Source for the byte representation.
      * 
-     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param colNum The (zero-based) column number that this Sink will be used for.
      * @param source The optional Source that can be used to read back the data for faster type inference.
      **/
     Sink<byte[]> forByte(int colNum, MutableObject<Source<byte[]>> source);
@@ -232,7 +232,7 @@ public interface SinkFactory {
     /**
      * Provide a Sink and optional Source for the short representation.
      * 
-     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param colNum The (zero-based) column number that this Sink will be used for.
      * @param source The optional Source that can be used to read back the data for faster type inference.
      **/
     Sink<short[]> forShort(int colNum, MutableObject<Source<short[]>> source);
@@ -243,7 +243,7 @@ public interface SinkFactory {
     /**
      * Provide a Sink and optional Source for the int representation.
      * 
-     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param colNum The (zero-based) column number that this Sink will be used for.
      * @param source The optional Source that can be used to read back the data for faster type inference.
      **/
     Sink<int[]> forInt(int colNum, MutableObject<Source<int[]>> source);
@@ -254,7 +254,7 @@ public interface SinkFactory {
     /**
      * Provide a Sink and optional Source for the long representation.
      * 
-     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param colNum The (zero-based) column number that this Sink will be used for.
      * @param source The optional Source that can be used to read back the data for faster type inference.
      **/
     Sink<long[]> forLong(int colNum, MutableObject<Source<long[]>> source);
@@ -265,7 +265,7 @@ public interface SinkFactory {
     /**
      * Provide a Sink for the float representation.
      * 
-     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param colNum The (zero-based) column number that this Sink will be used for.
      **/
     Sink<float[]> forFloat(int colNum);
 
@@ -275,7 +275,7 @@ public interface SinkFactory {
     /**
      * Provide a Sink for the double representation.
      * 
-     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param colNum The (zero-based) column number that this Sink will be used for.
      **/
     Sink<double[]> forDouble(int colNum);
 
@@ -285,7 +285,7 @@ public interface SinkFactory {
     /**
      * Provide a Sink for the booelan as byte representation.
      * 
-     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param colNum The (zero-based) column number that this Sink will be used for.
      **/
     Sink<byte[]> forBooleanAsByte(int colNum);
 
@@ -294,7 +294,7 @@ public interface SinkFactory {
     /**
      * Provide a Sink for the char representation.
      * 
-     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param colNum The (zero-based) column number that this Sink will be used for.
      **/
     Sink<char[]> forChar(int colNum);
 
@@ -304,7 +304,7 @@ public interface SinkFactory {
     /**
      * Provide a Sink for the String representation.
      * 
-     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param colNum The (zero-based) column number that this Sink will be used for.
      **/
     Sink<String[]> forString(int colNum);
 
@@ -314,7 +314,7 @@ public interface SinkFactory {
     /**
      * Provide a Sink for the datetime as long representation.
      * 
-     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param colNum The (zero-based) column number that this Sink will be used for.
      **/
     Sink<long[]> forDateTimeAsLong(int colNum);
 
@@ -324,7 +324,7 @@ public interface SinkFactory {
     /**
      * Provide a Sink for the Timestamp (as long) representation.
      * 
-     * @param colNum The (one-based) column number that this Sink will be used for.
+     * @param colNum The (zero-based) column number that this Sink will be used for.
      **/
     Sink<long[]> forTimestampAsLong(int colNum);
 

--- a/src/main/java/io/deephaven/csv/util/Moveable.java
+++ b/src/main/java/io/deephaven/csv/util/Moveable.java
@@ -1,7 +1,10 @@
 package io.deephaven.csv.util;
 
 /**
- * This class implements a kind of "moveable" semantics.
+ * This class implements a kind of "moveable" semantics. It exists because we really want the garbage collector to be
+ * able to clean up (prefixes of) our DenseStorage linked list when it can; and we don't want some careless programming
+ * error to leave a reference lying around that prevents it from doing so. This class makes it somewhat convenient to
+ * have single-owner and "move" semantics, so it's a little easier to not leak references.
  * 
  * @param <T>
  */

--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -1698,10 +1698,10 @@ public class CsvReaderTest {
         final int bh0Num = (Integer) col[0].data();
         final int bh1Num = (Integer) col[1].data();
         final int bh2Num = (Integer) col[2].data();
-        // 1-based column numbers
-        Assertions.assertThat(bh0Num).isEqualTo(1);
-        Assertions.assertThat(bh1Num).isEqualTo(2);
-        Assertions.assertThat(bh2Num).isEqualTo(3);
+        // 0-based column numbers
+        Assertions.assertThat(bh0Num).isEqualTo(0);
+        Assertions.assertThat(bh1Num).isEqualTo(1);
+        Assertions.assertThat(bh2Num).isEqualTo(2);
     }
 
     private static final class RepeatingInputStream extends InputStream {

--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -792,7 +792,7 @@ public class CsvReaderTest {
                 ColumnSet.of(
                         Column.ofValues("A", 1, 4), Column.ofValues("Qux", 2, 5), Column.ofValues("C", 3, 6));
 
-        invokeTest(defaultCsvBuilder().headers(List.of("A", "B", "C")).putHeaderForIndex(2, "Qux").build(), input,
+        invokeTest(defaultCsvBuilder().headers(List.of("A", "B", "C")).putHeaderForIndex(1, "Qux").build(), input,
                 expected);
     }
 
@@ -1074,7 +1074,7 @@ public class CsvReaderTest {
                                         .build(),
                                 input, ColumnSet.NONE))
                 .hasRootCauseMessage(
-                        "Row 4 is short, but can't null-fill it because there is no configured null value literal for column 2.");
+                        "Row 4 is short, but can't null-fill it because there is no configured null value literal for column \"B\".");
     }
 
     @Test
@@ -1561,8 +1561,8 @@ public class CsvReaderTest {
         invokeTest(
                 defaultCsvBuilder()
                         .parsers(Parsers.COMPLETE)
-                        .putNullValueLiteralsForIndex(1, Collections.singletonList("❌"))
-                        .putNullValueLiteralsForIndex(2, Collections.singletonList("🔥"))
+                        .putNullValueLiteralsForIndex(0, Collections.singletonList("❌"))
+                        .putNullValueLiteralsForIndex(1, Collections.singletonList("🔥"))
                         .putNullValueLiteralsForName("SomeInts", Collections.singletonList("⋰⋱"))
                         .putNullValueLiteralsForName("SomeLongs", Collections.singletonList("𝓓𝓮𝓮𝓹𝓱𝓪𝓿𝓮𝓷"))
                         .build(),
@@ -1660,7 +1660,7 @@ public class CsvReaderTest {
             final BigDecimal[] arr = ((List<BigDecimal>) obj).toArray(new BigDecimal[0]);
             return Column.ofArray(name, arr, size);
         };
-        invokeTest(defaultCsvBuilder().putParserForIndex(2, new MyBigDecimalParser()).build(), input, expected,
+        invokeTest(defaultCsvBuilder().putParserForIndex(1, new MyBigDecimalParser()).build(), input, expected,
                 makeMySinkFactory(), makeCustomColumn);
     }
 
@@ -1730,7 +1730,7 @@ public class CsvReaderTest {
         }
 
         @Override
-        public int read(@NotNull byte[] b, int off, int len) throws IOException {
+        public int read(byte @NotNull [] b, int off, int len) {
             if (len == 0) {
                 return 0;
             }


### PR DESCRIPTION
A feature request from Deephaven Enterprise: https://github.com/deephaven/deephaven-csv/issues/37
Also a bugfix where DateTimeAsLong and TimestampAsLong were referring to the wrong "reserved" value.
Also some small comment cleanups.