### PR TITLE
Bump fastdoubleparser from 0.3.0 to 0.5.0 and fix calling code

### DIFF
--- a/fast-double-parser-8/build.gradle
+++ b/fast-double-parser-8/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     api rootProject
 
     // Requires Java 8+
-    implementation 'ch.randelshofer:fastdoubleparser:0.2.0'
+    implementation 'ch.randelshofer:fastdoubleparser:0.5.0'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation(platform('org.junit:junit-bom:5.9.1'))

--- a/fast-double-parser-8/src/main/java/io/deephaven/csv/tokenization/FastCustomDoubleParser8.java
+++ b/fast-double-parser-8/src/main/java/io/deephaven/csv/tokenization/FastCustomDoubleParser8.java
@@ -1,6 +1,6 @@
 package io.deephaven.csv.tokenization;
 
-import ch.randelshofer.fastdoubleparser.FastDoubleParser;
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
 import io.deephaven.csv.containers.ByteSlice;
 import io.deephaven.csv.tokenization.Tokenizer.CustomDoubleParser;
 
@@ -11,25 +11,25 @@ import io.deephaven.csv.tokenization.Tokenizer.CustomDoubleParser;
  */
 public final class FastCustomDoubleParser8 implements CustomDoubleParser {
     /**
-     * Wraps the {@link ByteSlice} in a reusable {@link CharSequence} so that it can be passed to
-     * {@link #parse(CharSequence)}
+     * Equivalent to {@link JavaDoubleParser#parseDouble} (with the {@link ByteSlice} interpreted as a
+     * {@link CharSequence}.
      *
      * @param bs The byte slice.
-     * @return The parsed value if successful. Otherwise, throws NumberFormatException.
+     * @return The parsed value if successful. Otherwise, throws {@link NumberFormatException}.
      */
     @Override
     public double parse(ByteSlice bs) throws NumberFormatException {
-        return FastDoubleParser.parseDouble(bs);
+        return JavaDoubleParser.parseDouble(bs);
     }
 
     /**
-     * Equivalent to {@link FastDoubleParser#parseDouble}.
+     * Equivalent to {@link JavaDoubleParser#parseDouble}.
      *
      * @param cs the char sequence
-     * @return The parsed value if successful. Otherwise, throws NumberFormatException.
+     * @return The parsed value if successful. Otherwise, throws {@link NumberFormatException}.
      */
     @Override
     public double parse(CharSequence cs) throws NumberFormatException {
-        return FastDoubleParser.parseDouble(cs);
+        return JavaDoubleParser.parseDouble(cs);
     }
 }

--- a/fast-double-parser-8/src/main/java/io/deephaven/csv/tokenization/FastCustomDoubleParser8.java
+++ b/fast-double-parser-8/src/main/java/io/deephaven/csv/tokenization/FastCustomDoubleParser8.java
@@ -19,6 +19,11 @@ public final class FastCustomDoubleParser8 implements CustomDoubleParser {
      */
     @Override
     public double parse(ByteSlice bs) throws NumberFormatException {
+        // FastDoubleParser used to throw NumberFormatException on empty input. Now it throws IllegalArgumentException.
+        // We will make a change request at the FastDoubleParser project.
+        if (bs.size() == 0) {
+            throw new NumberFormatException("empty input");
+        }
         return JavaDoubleParser.parseDouble(bs);
     }
 

--- a/fast-double-parser/build.gradle
+++ b/fast-double-parser/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     api rootProject
 
     // Requires Java 11+
-    implementation 'ch.randelshofer:fastdoubleparser:0.3.0'
+    implementation 'ch.randelshofer:fastdoubleparser:0.5.0'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation(platform('org.junit:junit-bom:5.9.1'))

--- a/fast-double-parser/src/main/java/io/deephaven/csv/tokenization/FastCustomDoubleParser.java
+++ b/fast-double-parser/src/main/java/io/deephaven/csv/tokenization/FastCustomDoubleParser.java
@@ -1,7 +1,6 @@
 package io.deephaven.csv.tokenization;
 
-import ch.randelshofer.fastdoubleparser.FastDoubleParser;
-import ch.randelshofer.fastdoubleparser.FastDoubleParserFromByteArray;
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
 import io.deephaven.csv.containers.ByteSlice;
 import io.deephaven.csv.tokenization.Tokenizer.CustomDoubleParser;
 
@@ -20,7 +19,7 @@ public final class FastCustomDoubleParser implements CustomDoubleParser {
      */
     @Override
     public double parse(ByteSlice bs) throws NumberFormatException {
-        return FastDoubleParserFromByteArray.parseDouble(bs.data(), bs.begin(), bs.size());
+        return JavaDoubleParser.parseDouble(bs.data(), bs.begin(), bs.size());
     }
 
     /**
@@ -31,6 +30,6 @@ public final class FastCustomDoubleParser implements CustomDoubleParser {
      */
     @Override
     public double parse(CharSequence cs) throws NumberFormatException {
-        return FastDoubleParser.parseDouble(cs);
+        return JavaDoubleParser.parseDouble(cs);
     }
 }

--- a/fast-double-parser/src/main/java/io/deephaven/csv/tokenization/FastCustomDoubleParser.java
+++ b/fast-double-parser/src/main/java/io/deephaven/csv/tokenization/FastCustomDoubleParser.java
@@ -12,10 +12,10 @@ import io.deephaven.csv.tokenization.Tokenizer.CustomDoubleParser;
 public final class FastCustomDoubleParser implements CustomDoubleParser {
 
     /**
-     * Equivalent to {@code FastDoubleParserFromByteArray.parseDouble(bs.data(), bs.begin(), bs.size())}.
+     * Equivalent to {@code JavaDoubleParser.parseDouble(bs.data(), bs.begin(), bs.size())}.
      *
      * @param bs The byte slice.
-     * @return the parsed double
+     * @return The parsed value if successful. Otherwise, throws {@link NumberFormatException}.
      */
     @Override
     public double parse(ByteSlice bs) throws NumberFormatException {
@@ -23,10 +23,10 @@ public final class FastCustomDoubleParser implements CustomDoubleParser {
     }
 
     /**
-     * Equivalent to {@code FastDoubleParser.parseDouble(cs)}.
+     * Equivalent to {@link JavaDoubleParser#parseDouble}.
      *
      * @param cs the char sequence
-     * @return the parsed double
+     * @return The parsed value if successful. Otherwise, throws {@link NumberFormatException}.
      */
     @Override
     public double parse(CharSequence cs) throws NumberFormatException {

--- a/src/main/java/io/deephaven/csv/containers/ByteSlice.java
+++ b/src/main/java/io/deephaven/csv/containers/ByteSlice.java
@@ -99,11 +99,12 @@ public final class ByteSlice implements CharSequence {
     @NotNull
     @Override
     public CharSequence subSequence(final int start, final int end) {
+        // Beware: parameter 'end' shadows member variable 'this.end'.
         // Adjust start, end to be relative to this.begin.
-        final int newBegin = begin + start;
-        final int newEnd = begin + end;
+        final int newBegin = this.begin + start;
+        final int newEnd = this.begin + end;
         // Can't exceed bounds of current slice
-        if (newBegin < begin || newEnd > end || newBegin > newEnd) {
+        if (newBegin < this.begin || newEnd > this.end || newBegin > newEnd) {
             throw new IndexOutOfBoundsException("Invalid subsequence bounds");
         }
         return new ByteSlice(data, newBegin, newEnd);


### PR DESCRIPTION
This combines the change in https://github.com/deephaven/deephaven-csv/pull/75 with the code changes that fix the build.

If you'd rather add these changes to https://github.com/deephaven/deephaven-csv/pull/75 (I don't know how to do that) please let me know.
