### PR TITLE
Bump to JMH 1.36

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ tasks.named('test') { test ->
 }
 
 jmh {
-    jmhVersion = '1.34'
+    jmhVersion = '1.36'
     // -prof gc
     profilers = ['gc']
     // -rf JSON

--- a/jmh-result.main.json
+++ b/jmh-result.main.json
@@ -1,0 +1,244 @@
+[
+    {
+        "jmhVersion" : "1.34",
+        "benchmark" : "io.deephaven.csv.benchmark.datetimecol.DateTimeColumnBenchmark.deephaven",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/java-17-openjdk-17.0.5.0.8-2.fc36.x86_64/bin/java",
+        "jvmArgs" : [
+            "-Xms32G",
+            "-Xmx32G"
+        ],
+        "jdkVersion" : "17.0.5",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.5+8",
+        "warmupIterations" : 2,
+        "warmupTime" : "2 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.634288790618578E7,
+            "scoreError" : 991288.870885525,
+            "scoreConfidence" : [
+                1.5351599035300255E7,
+                1.7334176777071305E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.5308466980726207E7,
+                "50.0" : 1.6449308581569228E7,
+                "90.0" : 1.7296323219037082E7,
+                "95.0" : 1.733977140498467E7,
+                "99.0" : 1.733977140498467E7,
+                "99.9" : 1.733977140498467E7,
+                "99.99" : 1.733977140498467E7,
+                "99.999" : 1.733977140498467E7,
+                "99.9999" : 1.733977140498467E7,
+                "100.0" : 1.733977140498467E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.673582924649371E7,
+                    1.6262292135948706E7,
+                    1.5525984266502414E7,
+                    1.6636325027189748E7,
+                    1.733977140498467E7
+                ],
+                [
+                    1.6191513310875462E7,
+                    1.5742728068477096E7,
+                    1.5308466980726207E7,
+                    1.6780679075150996E7,
+                    1.6905289545508783E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.34",
+        "benchmark" : "io.deephaven.csv.benchmark.doublecol.DoubleColumnBenchmark.deephaven",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/java-17-openjdk-17.0.5.0.8-2.fc36.x86_64/bin/java",
+        "jvmArgs" : [
+            "-Xms32G",
+            "-Xmx32G"
+        ],
+        "jdkVersion" : "17.0.5",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.5+8",
+        "warmupIterations" : 2,
+        "warmupTime" : "2 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.3657411752148848E7,
+            "scoreError" : 1446039.2911998224,
+            "scoreConfidence" : [
+                2.2211372460949026E7,
+                2.510345104334867E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.223304417688246E7,
+                "50.0" : 2.38182060040555E7,
+                "90.0" : 2.504137199451752E7,
+                "95.0" : 2.5090175330170296E7,
+                "99.0" : 2.5090175330170296E7,
+                "99.9" : 2.5090175330170296E7,
+                "99.99" : 2.5090175330170296E7,
+                "99.999" : 2.5090175330170296E7,
+                "99.9999" : 2.5090175330170296E7,
+                "100.0" : 2.5090175330170296E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.5090175330170296E7,
+                    2.4602141973642543E7,
+                    2.443659838922076E7,
+                    2.3216024445616297E7,
+                    2.370938226115947E7
+                ],
+                [
+                    2.4122534457873426E7,
+                    2.267905054446765E7,
+                    2.3927029746951535E7,
+                    2.255813619550406E7,
+                    2.223304417688246E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.34",
+        "benchmark" : "io.deephaven.csv.benchmark.intcol.IntColumnBenchmark.deephaven",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/java-17-openjdk-17.0.5.0.8-2.fc36.x86_64/bin/java",
+        "jvmArgs" : [
+            "-Xms32G",
+            "-Xmx32G"
+        ],
+        "jdkVersion" : "17.0.5",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.5+8",
+        "warmupIterations" : 2,
+        "warmupTime" : "2 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.390800235011248E7,
+            "scoreError" : 359291.86211099365,
+            "scoreConfidence" : [
+                2.3548710488001484E7,
+                2.4267294212223474E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.3626361594454262E7,
+                "50.0" : 2.3869294027377024E7,
+                "90.0" : 2.424880624463359E7,
+                "95.0" : 2.425565503249438E7,
+                "99.0" : 2.425565503249438E7,
+                "99.9" : 2.425565503249438E7,
+                "99.99" : 2.425565503249438E7,
+                "99.999" : 2.425565503249438E7,
+                "99.9999" : 2.425565503249438E7,
+                "100.0" : 2.425565503249438E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.368954115777677E7,
+                    2.3987980352280077E7,
+                    2.3943546323097106E7,
+                    2.425565503249438E7,
+                    2.418716715388645E7
+                ],
+                [
+                    2.378505716888931E7,
+                    2.4175850418364435E7,
+                    2.379504173165694E7,
+                    2.3626361594454262E7,
+                    2.363382256822507E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.34",
+        "benchmark" : "io.deephaven.csv.benchmark.stringcol.StringColumnBenchmark.deephaven",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/java-17-openjdk-17.0.5.0.8-2.fc36.x86_64/bin/java",
+        "jvmArgs" : [
+            "-Xms32G",
+            "-Xmx32G"
+        ],
+        "jdkVersion" : "17.0.5",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.5+8",
+        "warmupIterations" : 2,
+        "warmupTime" : "2 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.5423960644971665E7,
+            "scoreError" : 959291.9496518198,
+            "scoreConfidence" : [
+                1.4464668695319844E7,
+                1.6383252594623486E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.4551869204130193E7,
+                "50.0" : 1.5459087164011043E7,
+                "90.0" : 1.636147800335968E7,
+                "95.0" : 1.6365036706700321E7,
+                "99.0" : 1.6365036706700321E7,
+                "99.9" : 1.6365036706700321E7,
+                "99.99" : 1.6365036706700321E7,
+                "99.999" : 1.6365036706700321E7,
+                "99.9999" : 1.6365036706700321E7,
+                "100.0" : 1.6365036706700321E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.4551869204130193E7,
+                    1.4712850664812535E7,
+                    1.483078753637226E7,
+                    1.5135658542570412E7,
+                    1.5286983439169237E7
+                ],
+                [
+                    1.5631190888852846E7,
+                    1.564817841806417E7,
+                    1.574760137575077E7,
+                    1.6329449673293896E7,
+                    1.6365036706700321E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/jmh-result.pr.json
+++ b/jmh-result.pr.json
@@ -1,0 +1,244 @@
+[
+    {
+        "jmhVersion" : "1.34",
+        "benchmark" : "io.deephaven.csv.benchmark.datetimecol.DateTimeColumnBenchmark.deephaven",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/java-17-openjdk-17.0.5.0.8-2.fc36.x86_64/bin/java",
+        "jvmArgs" : [
+            "-Xms32G",
+            "-Xmx32G"
+        ],
+        "jdkVersion" : "17.0.5",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.5+8",
+        "warmupIterations" : 2,
+        "warmupTime" : "2 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.685477473542344E7,
+            "scoreError" : 1400221.7932955774,
+            "scoreConfidence" : [
+                1.5454552942127861E7,
+                1.8254996528719015E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.5421886376803894E7,
+                "50.0" : 1.6792541690192796E7,
+                "90.0" : 1.8256799027257342E7,
+                "95.0" : 1.8297408958482187E7,
+                "99.0" : 1.8297408958482187E7,
+                "99.9" : 1.8297408958482187E7,
+                "99.99" : 1.8297408958482187E7,
+                "99.999" : 1.8297408958482187E7,
+                "99.9999" : 1.8297408958482187E7,
+                "100.0" : 1.8297408958482187E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7620403706386764E7,
+                    1.676550906991644E7,
+                    1.6671295922698548E7,
+                    1.7891309646233723E7,
+                    1.8297408958482187E7
+                ],
+                [
+                    1.6462531706056517E7,
+                    1.555382747174915E7,
+                    1.5421886376803894E7,
+                    1.681957431046915E7,
+                    1.7044000185437966E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.34",
+        "benchmark" : "io.deephaven.csv.benchmark.doublecol.DoubleColumnBenchmark.deephaven",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/java-17-openjdk-17.0.5.0.8-2.fc36.x86_64/bin/java",
+        "jvmArgs" : [
+            "-Xms32G",
+            "-Xmx32G"
+        ],
+        "jdkVersion" : "17.0.5",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.5+8",
+        "warmupIterations" : 2,
+        "warmupTime" : "2 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.3772045180155903E7,
+            "scoreError" : 1661449.5135714435,
+            "scoreConfidence" : [
+                2.211059566658446E7,
+                2.5433494693727348E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.2327065271341007E7,
+                "50.0" : 2.392228296970367E7,
+                "90.0" : 2.546694244369842E7,
+                "95.0" : 2.5498842050801907E7,
+                "99.0" : 2.5498842050801907E7,
+                "99.9" : 2.5498842050801907E7,
+                "99.99" : 2.5498842050801907E7,
+                "99.999" : 2.5498842050801907E7,
+                "99.9999" : 2.5498842050801907E7,
+                "100.0" : 2.5498842050801907E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.4027528093663905E7,
+                    2.384275819705975E7,
+                    2.2486048869735986E7,
+                    2.2327065271341007E7,
+                    2.238928848405138E7
+                ],
+                [
+                    2.5498842050801907E7,
+                    2.5179845979767032E7,
+                    2.3844839170728665E7,
+                    2.4124508915730752E7,
+                    2.3999726768678676E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.34",
+        "benchmark" : "io.deephaven.csv.benchmark.intcol.IntColumnBenchmark.deephaven",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/java-17-openjdk-17.0.5.0.8-2.fc36.x86_64/bin/java",
+        "jvmArgs" : [
+            "-Xms32G",
+            "-Xmx32G"
+        ],
+        "jdkVersion" : "17.0.5",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.5+8",
+        "warmupIterations" : 2,
+        "warmupTime" : "2 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.3803778718595874E7,
+            "scoreError" : 351848.5519016543,
+            "scoreConfidence" : [
+                2.345193016669422E7,
+                2.4155627270497527E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.3445004773502614E7,
+                "50.0" : 2.3795336760226913E7,
+                "90.0" : 2.4225309332018074E7,
+                "95.0" : 2.425164184173056E7,
+                "99.0" : 2.425164184173056E7,
+                "99.9" : 2.425164184173056E7,
+                "99.99" : 2.425164184173056E7,
+                "99.999" : 2.425164184173056E7,
+                "99.9999" : 2.425164184173056E7,
+                "100.0" : 2.425164184173056E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.3445004773502614E7,
+                    2.364910922237452E7,
+                    2.3807161836756438E7,
+                    2.398280692601914E7,
+                    2.3783511683697384E7
+                ],
+                [
+                    2.3988316744605698E7,
+                    2.425164184173056E7,
+                    2.3715535458125427E7,
+                    2.385108205320225E7,
+                    2.35636166459447E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.34",
+        "benchmark" : "io.deephaven.csv.benchmark.stringcol.StringColumnBenchmark.deephaven",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/lib/jvm/java-17-openjdk-17.0.5.0.8-2.fc36.x86_64/bin/java",
+        "jvmArgs" : [
+            "-Xms32G",
+            "-Xmx32G"
+        ],
+        "jdkVersion" : "17.0.5",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.5+8",
+        "warmupIterations" : 2,
+        "warmupTime" : "2 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.8396292776643604E7,
+            "scoreError" : 3315108.4965152848,
+            "scoreConfidence" : [
+                1.5081184280128319E7,
+                2.171140127315889E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.597513027184069E7,
+                "50.0" : 1.834948858289934E7,
+                "90.0" : 2.1073655440774746E7,
+                "95.0" : 2.1083542044938315E7,
+                "99.0" : 2.1083542044938315E7,
+                "99.9" : 2.1083542044938315E7,
+                "99.99" : 2.1083542044938315E7,
+                "99.999" : 2.1083542044938315E7,
+                "99.9999" : 2.1083542044938315E7,
+                "100.0" : 2.1083542044938315E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.9702605942044064E7,
+                    1.9889758246265724E7,
+                    2.0419663298199918E7,
+                    2.0984676003302615E7,
+                    2.1083542044938315E7
+                ],
+                [
+                    1.61053842486844E7,
+                    1.597513027184069E7,
+                    1.601323947813166E7,
+                    1.6792557009274047E7,
+                    1.6996371223754615E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+


### PR DESCRIPTION
The changes are maintenance releases.

JMH 1.35: https://mail.openjdk.org/pipermail/jmh-dev/2022-March/003422.html
JMH 1.36: https://mail.openjdk.org/pipermail/jmh-dev/2022-November/003553.html