### PR TITLE
Add manifest attributes to the JARs

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.csv.java-publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.csv.java-publishing-conventions.gradle
@@ -88,3 +88,18 @@ signing {
         useInMemoryPgpKeys(signingKey, signingPassword)
     }
 }
+
+tasks.withType(Jar).configureEach {
+    manifest {
+        attributes(
+                'Specification-Title': archivesBaseName,
+                'Specification-Version': project.version,
+                'Specification-Vendor': orgName,
+                'Implementation-Title': archivesBaseName,
+                'Implementation-Version': project.version,
+                'Implementation-Vendor': orgName,
+                'Implementation-Vendor-Id': project.group,
+                'Implementation-URL': projectUrl,
+                'Bundle-License': licenseUrl)
+    }
+}


### PR DESCRIPTION
This is in an effort to provide more structured details for SBOM tooling introspection.

Of particular interest is to improve fields (purl, licenses) with respect to https://github.com/anchore/syft.

```
./gradlew jar
syft build/libs/deephaven-csv-0.10.0-SNAPSHOT.jar -o json
```

See https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Main_Attributes for more information about attributes.