### PR TITLE
Fix deadlock when a sequence of long-ish strings appear in the input (bug #101)

### DIFF
--- a/src/main/java/io/deephaven/csv/densestorage/DenseStorageWriter.java
+++ b/src/main/java/io/deephaven/csv/densestorage/DenseStorageWriter.java
@@ -138,7 +138,7 @@ public final class DenseStorageWriter {
         // flow control is based on limiting the number of data queue blocks outstanding
         // (per DenseStorageConstants.MAX_UNOBSERVED_BLOCKS). We want to flush the control queue every
         // time we fill a block on the data queue, so the consumer has a chance to consume the data. If we
-        // did not do this, in some cases the data queue would run too far ahead, the flow control be invoked
+        // did not do this, in some cases the data queue would run too far ahead, the flow control would be invoked
         // to block the writer, but the reader would also be blocked because it is still waiting on control queue
         // notifications, which haven't arrived because the latest control queue block isn't full and hasn't
         // been flushed yet. See https://github.com/deephaven/deephaven-csv/issues/101.

--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -141,7 +141,8 @@ public class CsvReaderTest {
     public void bug101() throws CsvReaderException {
         final int numCharsInBigCell = DenseStorageConstants.LARGE_THRESHOLD - 1;
         final int numStringsThatFitInAQueueBlock = DenseStorageConstants.PACKED_QUEUE_SIZE / numCharsInBigCell;
-        final int numRowsThatWillTriggerTheDeadlock = numStringsThatFitInAQueueBlock * (DenseStorageConstants.MAX_UNOBSERVED_BLOCKS + 1);
+        final int numRowsThatWillTriggerTheDeadlock =
+                numStringsThatFitInAQueueBlock * (DenseStorageConstants.MAX_UNOBSERVED_BLOCKS + 1);
 
         final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < numCharsInBigCell; ++i) {


### PR DESCRIPTION
Background: we have FIFO queues between the thread that parses the input into cells, and the threads for each column that parse those cells into data.

Each FIFO queue is in turn composed of a "control queue" and a "data queue". The control queue indicates what kind of data cell was pushed onto the data queue (there are two choices: either a short-ish string, packed with other strings into a block, or a longer string in its own byte[] array).

Importantly, because our flow control is based on limiting the number of data queue blocks outstanding (per `DenseStorageConstants.MAX_UNOBSERVED_BLOCKS`), we want to flush the control queue every time we fill a block on the data queue, so the consumer has a chance to consume the data. If we did not do this, in some cases the data queue would run too far ahead, the flow control be invoked to block the writer, but the reader would also be blocked because it is still waiting on control queue notifications, which haven't arrived because the latest control queue block isn't full and hasn't been flushed yet.

See https://github.com/deephaven/deephaven-csv/issues/101
