### PR TITLE
Use gradle property to control signing.required

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,3 +44,4 @@ jobs:
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.CI_AT_DEEPHAVEN_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.CI_AT_DEEPHAVEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingRequired: true

--- a/buildSrc/src/main/groovy/io.deephaven.csv.java-publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.csv.java-publishing-conventions.gradle
@@ -80,6 +80,7 @@ publishing {
 }
 
 signing {
+    required = "true" == findProperty('signingRequired')
     sign publishing.publications.mavenJava
     String signingKey = findProperty('signingKey')
     String signingPassword = findProperty('signingPassword')


### PR DESCRIPTION
Adds gradle property signingRequired. This allows developers to use `./gradlew publishToMavenLocal` instead of `./gradlew publishToMavenLocal -x signMavenJavaPublication`.

See https://github.com/deephaven/deephaven-core/pull/3846

See https://github.com/gradle/gradle/issues/24456