### PR TITLE
Add direct executor in non-concurrent case

### DIFF
--- a/src/jmh/java/io/deephaven/csv/benchmark/datetimecol/DateTimeColumnBenchmark.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/datetimecol/DateTimeColumnBenchmark.java
@@ -58,9 +58,16 @@ public class DateTimeColumnBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(OPERATIONS)
+    public BenchmarkResult<long[]> deephavenSingle(final InputProvider input, final ReusableStorage storage)
+            throws Exception {
+        return DateTimeColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output, false);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(OPERATIONS)
     public BenchmarkResult<long[]> deephaven(final InputProvider input, final ReusableStorage storage)
             throws Exception {
-        return DateTimeColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output);
+        return DateTimeColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output, true);
     }
 
     @Benchmark

--- a/src/jmh/java/io/deephaven/csv/benchmark/datetimecol/DateTimeColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/datetimecol/DateTimeColumnParserDeephaven.java
@@ -12,11 +12,13 @@ import java.util.Arrays;
 import java.util.Collections;
 
 public final class DateTimeColumnParserDeephaven {
-    public static BenchmarkResult<long[]> read(final InputStream in, final long[][] storage) throws Exception {
+    public static BenchmarkResult<long[]> read(final InputStream in, final long[][] storage, boolean concurrent)
+            throws Exception {
         final SinkFactory sinkFactory = SinkFactories.makeRecyclingSinkFactory(null, null, null, null, null, storage);
         final CsvSpecs specs = CsvSpecs.builder()
                 .parsers(Collections.singleton(Parsers.DATETIME))
                 .hasHeaderRow(true)
+                .concurrent(concurrent)
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final long[][] data = Arrays.stream(result.columns())

--- a/src/jmh/java/io/deephaven/csv/benchmark/doublecol/DoubleColumnBenchmark.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/doublecol/DoubleColumnBenchmark.java
@@ -46,9 +46,16 @@ public class DoubleColumnBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(OPERATIONS)
+    public BenchmarkResult<double[]> deephavenSingle(final InputProvider input, final ReusableStorage storage)
+            throws Exception {
+        return DoubleColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output, false);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(OPERATIONS)
     public BenchmarkResult<double[]> deephaven(final InputProvider input, final ReusableStorage storage)
             throws Exception {
-        return DoubleColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output);
+        return DoubleColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output, true);
     }
 
     @Benchmark

--- a/src/jmh/java/io/deephaven/csv/benchmark/doublecol/DoubleColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/doublecol/DoubleColumnParserDeephaven.java
@@ -12,11 +12,13 @@ import java.util.Arrays;
 import java.util.Collections;
 
 public final class DoubleColumnParserDeephaven {
-    public static BenchmarkResult<double[]> read(final InputStream in, final double[][] storage) throws Exception {
+    public static BenchmarkResult<double[]> read(final InputStream in, final double[][] storage, boolean concurrent)
+            throws Exception {
         final SinkFactory sinkFactory = SinkFactories.makeRecyclingSinkFactory(null, null, null, storage, null, null);
         final CsvSpecs specs = CsvSpecs.builder()
                 .parsers(Collections.singleton(Parsers.DOUBLE))
                 .hasHeaderRow(true)
+                .concurrent(concurrent)
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final double[][] data = Arrays.stream(result.columns())

--- a/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnBenchmark.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnBenchmark.java
@@ -46,8 +46,15 @@ public class IntColumnBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(OPERATIONS)
+    public BenchmarkResult<int[]> deephavenSingle(final InputProvider input, final ReusableStorage storage)
+            throws Exception {
+        return IntColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output, false);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(OPERATIONS)
     public BenchmarkResult<int[]> deephaven(final InputProvider input, final ReusableStorage storage) throws Exception {
-        return IntColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output);
+        return IntColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output, true);
     }
 
     @Benchmark

--- a/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/intcol/IntColumnParserDeephaven.java
@@ -12,11 +12,13 @@ import java.util.Arrays;
 import java.util.Collections;
 
 public final class IntColumnParserDeephaven {
-    public static BenchmarkResult<int[]> read(final InputStream in, final int[][] storage) throws Exception {
+    public static BenchmarkResult<int[]> read(final InputStream in, final int[][] storage, boolean concurrent)
+            throws Exception {
         final SinkFactory sinkFactory = SinkFactories.makeRecyclingSinkFactory(null, storage, null, null, null, null);
         final CsvSpecs specs = CsvSpecs.builder()
                 .parsers(Collections.singleton(Parsers.INT))
                 .hasHeaderRow(true)
+                .concurrent(concurrent)
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final int[][] data = Arrays.stream(result.columns())

--- a/src/jmh/java/io/deephaven/csv/benchmark/largenumericonly/LargeNumericOnlyBenchmark.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/largenumericonly/LargeNumericOnlyBenchmark.java
@@ -117,8 +117,14 @@ public class LargeNumericOnlyBenchmark {
     }
 
     @Benchmark
+    public void deephavenSingle(InputProvider ip, final ReusableStorage storage, final Blackhole bh) throws Exception {
+        final Results results = LargeNumericOnlyDeephaven.read(ip.makeStream(), storage.results, false);
+        bh.consume(results);
+    }
+
+    @Benchmark
     public void deephaven(InputProvider ip, final ReusableStorage storage, final Blackhole bh) throws Exception {
-        final Results results = LargeNumericOnlyDeephaven.read(ip.makeStream(), storage.results);
+        final Results results = LargeNumericOnlyDeephaven.read(ip.makeStream(), storage.results, true);
         bh.consume(results);
     }
 }

--- a/src/jmh/java/io/deephaven/csv/benchmark/largenumericonly/LargeNumericOnlyDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/largenumericonly/LargeNumericOnlyDeephaven.java
@@ -4,13 +4,12 @@ import io.deephaven.csv.CsvSpecs;
 import io.deephaven.csv.benchmark.util.SinkFactories;
 import io.deephaven.csv.parsers.Parsers;
 import io.deephaven.csv.reading.CsvReader;
-import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.sinks.SinkFactory;
 
 import java.io.InputStream;
 
 public class LargeNumericOnlyDeephaven {
-    public static Results read(final InputStream in, final Results results) throws Exception {
+    public static Results read(final InputStream in, final Results results, boolean concurrent) throws Exception {
         final SinkFactory sinkFactory = SinkFactories.makeRecyclingSinkFactory(
                 null,
                 null,
@@ -21,6 +20,7 @@ public class LargeNumericOnlyDeephaven {
 
         final CsvSpecs specs = CsvSpecs.builder()
                 .hasHeaderRow(true)
+                .concurrent(concurrent)
                 .putParserForIndex(1, Parsers.LONG)
                 .putParserForIndex(2, Parsers.LONG)
                 .putParserForIndex(3, Parsers.LONG)

--- a/src/jmh/java/io/deephaven/csv/benchmark/largetable/LargeTableBenchmark.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/largetable/LargeTableBenchmark.java
@@ -1,6 +1,5 @@
 package io.deephaven.csv.benchmark.largetable;
 
-import io.deephaven.csv.benchmark.doublecol.DoubleColumnBenchmark;
 import io.deephaven.csv.benchmark.util.Util;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
@@ -142,8 +141,14 @@ public class LargeTableBenchmark {
     }
 
     @Benchmark
+    public void deephavenSingle(InputProvider ip, final ReusableStorage storage, final Blackhole bh) throws Exception {
+        final Results results = LargeTableDeephaven.read(ip.makeStream(), storage.results, false);
+        bh.consume(results);
+    }
+
+    @Benchmark
     public void deephaven(InputProvider ip, final ReusableStorage storage, final Blackhole bh) throws Exception {
-        final Results results = LargeTableDeephaven.read(ip.makeStream(), storage.results);
+        final Results results = LargeTableDeephaven.read(ip.makeStream(), storage.results, true);
         bh.consume(results);
     }
 

--- a/src/jmh/java/io/deephaven/csv/benchmark/largetable/LargeTableDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/largetable/LargeTableDeephaven.java
@@ -4,13 +4,12 @@ import io.deephaven.csv.CsvSpecs;
 import io.deephaven.csv.benchmark.util.SinkFactories;
 import io.deephaven.csv.parsers.Parsers;
 import io.deephaven.csv.reading.CsvReader;
-import io.deephaven.csv.sinks.Sink;
 import io.deephaven.csv.sinks.SinkFactory;
 
 import java.io.InputStream;
 
 public class LargeTableDeephaven {
-    public static Results read(final InputStream in, final Results results) throws Exception {
+    public static Results read(final InputStream in, final Results results, boolean concurrent) throws Exception {
         final SinkFactory sinkFactory = SinkFactories.makeRecyclingSinkFactory(
                 new byte[][] {results.boolsAsBytes},
                 null,
@@ -20,6 +19,7 @@ public class LargeTableDeephaven {
                 new long[][] {results.timestamps});
         final CsvSpecs specs = CsvSpecs.builder()
                 .hasHeaderRow(true)
+                .concurrent(concurrent)
                 .putParserForIndex(1, Parsers.DATETIME)
                 .putParserForIndex(2, Parsers.STRING)
                 .putParserForIndex(3, Parsers.BOOLEAN)

--- a/src/jmh/java/io/deephaven/csv/benchmark/stringcol/StringColumnBenchmark.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/stringcol/StringColumnBenchmark.java
@@ -69,9 +69,16 @@ public class StringColumnBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(OPERATIONS)
+    public BenchmarkResult<String[]> deephavenSingle(final InputProvider input, final ReusableStorage storage)
+            throws Exception {
+        return StringColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output(), false);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(OPERATIONS)
     public BenchmarkResult<String[]> deephaven(final InputProvider input, final ReusableStorage storage)
             throws Exception {
-        return StringColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output());
+        return StringColumnParserDeephaven.read(input.tableMaker.makeStream(), storage.output(), true);
     }
 
     @Benchmark

--- a/src/jmh/java/io/deephaven/csv/benchmark/stringcol/StringColumnParserDeephaven.java
+++ b/src/jmh/java/io/deephaven/csv/benchmark/stringcol/StringColumnParserDeephaven.java
@@ -12,11 +12,13 @@ import java.util.Arrays;
 import java.util.Collections;
 
 public final class StringColumnParserDeephaven {
-    public static BenchmarkResult<String[]> read(final InputStream in, final String[][] storage) throws Exception {
+    public static BenchmarkResult<String[]> read(final InputStream in, final String[][] storage, boolean concurrent)
+            throws Exception {
         final SinkFactory sinkFactory = SinkFactories.makeRecyclingSinkFactory(null, null, null, null, storage, null);
         final CsvSpecs specs = CsvSpecs.builder()
                 .parsers(Collections.singleton(Parsers.STRING))
                 .hasHeaderRow(true)
+                .concurrent(concurrent)
                 .build();
         final CsvReader.Result result = CsvReader.read(specs, in, sinkFactory);
         final String[][] data = Arrays.stream(result.columns())


### PR DESCRIPTION
This allows us to perform the operations on thread as opposed to submitting to a single-threaded executor.

Additionally, breaks apart the Deephaven benchmarks into concurrent and non-concurrent versions.