### PR TITLE
Add fixed-width column support

### DIFF
--- a/src/main/java/io/deephaven/csv/CsvSpecs.java
+++ b/src/main/java/io/deephaven/csv/CsvSpecs.java
@@ -118,6 +118,34 @@ public abstract class CsvSpecs {
         Builder headerValidator(Predicate<String> headerValidator);
 
         /**
+         * True if the input is organized into fixed width columns rather than delimited by a delimiter.
+         */
+        Builder hasFixedWidthColumns(boolean hasFixedWidthColumns);
+
+        /**
+         * When {@link #hasFixedWidthColumns} is set, the library either determines the column widths from the header
+         * row (provided {@link #hasHeaderRow} is set), or the column widths can be specified explictly by the caller.
+         * If the caller wants to specify them explicitly, they can use this method.
+         * 
+         * @param fixedColumnWidths The caller-specified widths of the columns.
+         */
+        Builder fixedColumnWidths(Iterable<Integer> fixedColumnWidths);
+
+        /**
+         * This setting controls what units fixed width columns are measured in. When true, fixed width columns are
+         * measured in Unicode code points. When false, fixed width columns are measured in UTF-16 units (aka Java
+         * chars). The difference arises when encountering characters outside the Unicode Basic Multilingual Plane. For
+         * example, the Unicode code point 💔 (U+1F494) is one Unicode code point, but takes two Java chars to
+         * represent. Along these lines, the string 💔💔💔 would fit in a column of width 3 when utf32CountingMode is
+         * true, but would require a column width of at least 6 when utf32CountingMode is false.
+         *
+         * The default setting of true is arguably more natural for users (the number of characters they see matches the
+         * visual width of the column). But some programs may want the value of false because they are counting Java
+         * chars.
+         */
+        Builder useUtf32CountingConvention(boolean useUtf32CountingConvention);
+
+        /**
          * Number of data rows to skip before processing data. This is useful when you want to parse data in chunks.
          * Typically used together with {@link Builder#numRows}. Defaults to 0.
          */
@@ -338,6 +366,30 @@ public abstract class CsvSpecs {
     @Default
     public Predicate<String> headerValidator() {
         return c -> true;
+    }
+
+    /**
+     * See {@link Builder#hasFixedWidthColumns}.
+     */
+    @Default
+    public boolean hasFixedWidthColumns() {
+        return false;
+    }
+
+    /**
+     * See {@link Builder#fixedColumnWidths}.
+     */
+    @Default
+    public List<Integer> fixedColumnWidths() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * See {@link Builder#useUtf32CountingConvention}.
+     */
+    @Default
+    public boolean useUtf32CountingConvention() {
+        return true;
     }
 
     /**

--- a/src/main/java/io/deephaven/csv/reading/cells/FixedCellGrabber.java
+++ b/src/main/java/io/deephaven/csv/reading/cells/FixedCellGrabber.java
@@ -1,0 +1,113 @@
+package io.deephaven.csv.reading.cells;
+
+import io.deephaven.csv.containers.ByteSlice;
+import io.deephaven.csv.reading.ReaderUtil;
+import io.deephaven.csv.util.CsvReaderException;
+import io.deephaven.csv.util.MutableBoolean;
+import io.deephaven.csv.util.MutableInt;
+
+import java.io.InputStream;
+
+/**
+ * This class uses an underlying DelimitedCellGrabber to grab whole lines at a time from the input stream, and then it
+ * breaks them into fixed-sized cells to return to the caller.
+ */
+public class FixedCellGrabber implements CellGrabber {
+    /**
+     * Makes a degenerate CellGrabber that has no delimiters or quotes and therefore returns whole lines. This is a
+     * somewhat quick-and-dirty way to reuse the buffering and newline logic in DelimitedCellGrabber without rewriting
+     * it.
+     * 
+     * @param stream The underlying stream.
+     * @return The "line grabber"
+     */
+    public static CellGrabber makeLineGrabber(InputStream stream) {
+        final byte IllegalUtf8 = (byte) 0xff;
+        return new DelimitedCellGrabber(stream, IllegalUtf8, IllegalUtf8, true, false);
+    }
+
+    private final CellGrabber lineGrabber;
+    private final int[] columnWidths;
+    private final boolean ignoreSurroundingSpaces;
+    private final boolean utf32CountingMode;
+    private final ByteSlice rowText;
+    private boolean needsUnderlyingRefresh;
+    private int colIndex;
+    private final MutableBoolean dummy1;
+    private final MutableInt dummy2;
+
+    /** Constructor. */
+    public FixedCellGrabber(final CellGrabber lineGrabber, final int[] columnWidths, boolean ignoreSurroundingSpaces,
+            boolean utf32CountingMode) {
+        this.lineGrabber = lineGrabber;
+        this.columnWidths = columnWidths;
+        this.ignoreSurroundingSpaces = ignoreSurroundingSpaces;
+        this.utf32CountingMode = utf32CountingMode;
+        this.rowText = new ByteSlice();
+        this.needsUnderlyingRefresh = true;
+        this.colIndex = 0;
+        this.dummy1 = new MutableBoolean();
+        this.dummy2 = new MutableInt();
+    }
+
+    @Override
+    public void grabNext(ByteSlice dest, MutableBoolean lastInRow, MutableBoolean endOfInput)
+            throws CsvReaderException {
+        if (needsUnderlyingRefresh) {
+            // Underlying row used up, and all columns provided. Ask underlying CellGrabber for the next line.
+            lineGrabber.grabNext(rowText, dummy1, endOfInput);
+
+            if (endOfInput.booleanValue()) {
+                // Set dest to the empty string, and leave 'endOfInput' set to true.
+                dest.reset(rowText.data(), rowText.end(), rowText.end());
+                return;
+            }
+
+            needsUnderlyingRefresh = false;
+            colIndex = 0;
+        }
+
+        // There is data to return. Count off N characters. The final column gets all remaining characters.
+        final boolean lastCol = colIndex == columnWidths.length - 1;
+        final int numCharsToTake = lastCol ? Integer.MAX_VALUE : columnWidths[colIndex];
+        takeNCharactersInCharset(rowText, dest, numCharsToTake, utf32CountingMode, dummy2);
+        ++colIndex;
+        needsUnderlyingRefresh = lastCol || dest.size() == 0;
+        lastInRow.setValue(needsUnderlyingRefresh);
+        endOfInput.setValue(false);
+
+        if (ignoreSurroundingSpaces) {
+            ReaderUtil.trimSpacesAndTabs(dest);
+        }
+    }
+
+    private static void takeNCharactersInCharset(ByteSlice src, ByteSlice dest, int numCharsToTake,
+            boolean utf32CountingMode, MutableInt tempInt) {
+        final byte[] data = src.data();
+        final int cellBegin = src.begin();
+        int current = cellBegin;
+        while (numCharsToTake > 0) {
+            if (current == src.end()) {
+                break;
+            }
+            final int utf8Length = ReaderUtil.getUtf8LengthAndCharLength(data[current], src.end() - current,
+                    utf32CountingMode, tempInt);
+            if (numCharsToTake < tempInt.intValue()) {
+                // There is not enough space left in the field to store this character.
+                // This can happen if CsvSpecs is set for the UTF16 counting convention,
+                // there is one unit left in the field, and we encounter a character outside
+                // the Basic Multilingual Plane, which would require two units.
+                break;
+            }
+            numCharsToTake -= tempInt.intValue();
+            current += utf8Length;
+        }
+        dest.reset(src.data(), cellBegin, current);
+        src.reset(src.data(), current, src.end());
+    }
+
+    @Override
+    public int physicalRowNum() {
+        return lineGrabber.physicalRowNum();
+    }
+}

--- a/src/main/java/io/deephaven/csv/reading/headers/FixedHeaderFinder.java
+++ b/src/main/java/io/deephaven/csv/reading/headers/FixedHeaderFinder.java
@@ -1,0 +1,199 @@
+package io.deephaven.csv.reading.headers;
+
+import io.deephaven.csv.CsvSpecs;
+import io.deephaven.csv.containers.ByteSlice;
+import io.deephaven.csv.reading.ReaderUtil;
+import io.deephaven.csv.reading.cells.CellGrabber;
+import io.deephaven.csv.tokenization.Tokenizer;
+import io.deephaven.csv.util.CsvReaderException;
+import io.deephaven.csv.util.MutableBoolean;
+import io.deephaven.csv.util.MutableInt;
+import io.deephaven.csv.util.MutableObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class FixedHeaderFinder {
+    /**
+     * Determine which headers to use. The result comes from either the first row of the file or the user-specified
+     * overrides.
+     */
+    public static String[] determineHeadersToUse(
+            final CsvSpecs specs,
+            final CellGrabber lineGrabber,
+            MutableObject<int[]> columnWidthsResult)
+            throws CsvReaderException {
+        String[] headersToUse;
+        // Get user-specified column widths, if any. If none were specified, this will be an array of length 0.
+        // The column widths are in units of the specified convention (either UTF-16 or UTF-32 units).
+        int[] columnWidthsToUse = specs.fixedColumnWidths().stream().mapToInt(Integer::intValue).toArray();
+        if (specs.hasHeaderRow()) {
+            long skipCount = specs.skipHeaderRows();
+            final ByteSlice headerRow = new ByteSlice();
+            MutableBoolean lastInRow = new MutableBoolean();
+            MutableBoolean endOfInput = new MutableBoolean();
+            while (true) {
+                lineGrabber.grabNext(headerRow, lastInRow, endOfInput);
+                if (endOfInput.booleanValue()) {
+                    throw new CsvReaderException(
+                            "Can't proceed because hasHeaderRow is set but input file is empty or shorter than skipHeaderRows");
+                }
+                if (skipCount == 0) {
+                    break;
+                }
+                --skipCount;
+            }
+            if (columnWidthsToUse.length == 0) {
+                columnWidthsToUse = inferColumnWidths(headerRow, specs.useUtf32CountingConvention());
+            }
+
+            headersToUse =
+                    extractHeaders(headerRow, columnWidthsToUse, specs.useUtf32CountingConvention());
+        } else {
+            if (columnWidthsToUse.length == 0) {
+                throw new CsvReaderException(
+                        "Can't proceed because hasHeaderRow is false but fixedColumnWidths is unspecified");
+            }
+            headersToUse = ReaderUtil.makeSyntheticHeaders(columnWidthsToUse.length);
+        }
+
+        // Whether or not the input had headers, maybe override with client-specified headers.
+        if (specs.headers().size() != 0) {
+            if (specs.headers().size() != headersToUse.length) {
+                final String message = String.format("Library determined %d headers; caller overrode with %d headers",
+                        headersToUse.length, specs.headers().size());
+                throw new CsvReaderException(message);
+            }
+            headersToUse = specs.headers().toArray(new String[0]);
+        }
+
+        // Apply column specific overrides.
+        for (Map.Entry<Integer, String> entry : specs.headerForIndex().entrySet()) {
+            headersToUse[entry.getKey()] = entry.getValue();
+        }
+
+        columnWidthsResult.setValue(columnWidthsToUse);
+        return headersToUse;
+    }
+
+    /**
+     * Infer the column widths by looking for the transition from delimiter char to non-delimiter char.
+     * 
+     * @param row The input row
+     * @param useUtf32CountingConvention The character set convention we are using for units of width (either UTF-32 or
+     *        UTF-16)
+     * @return The widths of the columns, in the specified character set convention.
+     */
+    private static int[] inferColumnWidths(ByteSlice row, boolean useUtf32CountingConvention) {
+        // A column start is a non-delimiter character preceded by a delimiter (or present at the start of line).
+        // If the start of the line is a delimiter, that is an error.
+        final List<Integer> columnWidths = new ArrayList<>();
+        final MutableInt charCountResult = new MutableInt();
+        boolean prevCharIsSpace = false;
+        final byte[] data = row.data();
+        int numChars = 0;
+        int currentIndex = row.begin();
+        while (true) {
+            if (currentIndex == row.end()) {
+                columnWidths.add(numChars);
+                return columnWidths.stream().mapToInt(Integer::intValue).toArray();
+            }
+            // If this character is not a delimiter, but the previous one was, then this is the start of a new column.
+            byte ch = data[currentIndex];
+            boolean thisCharIsSpace = ch == ' ';
+            if (currentIndex == row.begin() && thisCharIsSpace) {
+                throw new IllegalArgumentException("Header row cannot start with a space");
+            }
+            if (!thisCharIsSpace && prevCharIsSpace) {
+                columnWidths.add(numChars);
+                numChars = 0;
+            }
+            prevCharIsSpace = thisCharIsSpace;
+            final int utf8Length = ReaderUtil.getUtf8LengthAndCharLength(ch, row.end() - currentIndex,
+                    useUtf32CountingConvention, charCountResult);
+            currentIndex += utf8Length;
+            numChars += charCountResult.intValue();
+        }
+    }
+
+    /**
+     * Extract the headers names from 'row'.
+     * 
+     * @param row The header row
+     * @param columnWidths The width of the columns, in the UTF-32 or UTF-16 counting convention.
+     * @param utf32CountingMode Whether we are in the UTF-32 or UTF-16 counting mode
+     * @return The array of headers
+     */
+    private static String[] extractHeaders(ByteSlice row, int[] columnWidths, boolean utf32CountingMode) {
+        final int numCols = columnWidths.length;
+        if (numCols == 0) {
+            return new String[0];
+        }
+        final int[] byteWidths = new int[numCols];
+        final ByteSlice tempSlice = new ByteSlice();
+        final int excessBytes = charWidthsToByteWidths(row, columnWidths, utf32CountingMode, byteWidths);
+        // Our policy is that the last column gets any excess bytes that are in the row.
+        byteWidths[numCols - 1] += excessBytes;
+        final String[] result = new String[numCols];
+
+        int beginByte = row.begin();
+        for (int colNum = 0; colNum != numCols; ++colNum) {
+            final int proposedEndByte = beginByte + byteWidths[colNum];
+            final int actualEndByte = Math.min(proposedEndByte, row.end());
+            tempSlice.reset(row.data(), beginByte, actualEndByte);
+            ReaderUtil.trimSpacesAndTabs(tempSlice);
+            result[colNum] = tempSlice.toString();
+            beginByte = actualEndByte;
+        }
+        return result;
+    }
+
+    /**
+     * Convert character widths to UTF-8 widths. This converts the character widths, which are in the specified
+     * convention (either UTF-16 or UTF-32), which are fixed for the whole input, and which are determined by reading
+     * the headers (or specified by the user), into UTF-8 widths, which are specific to this row. For example if a
+     * charWidth is 2 and the utf32CountingMode is true, then we need to scan the row for the next two Unicode
+     * characters and count how many UTF-8 bytes that took up.
+     * 
+     * @param row The row we are processing
+     * @param charWidths The column widths, in units of UTF-32 or UTF-16 units.
+     * @param utf32CountingMode Whether we are counting in UTF-32 or UTF-16 mode
+     * @param byteWidths The corresponding number of UTF-8 bytes corresponding to the charWidths for this row.
+     * @return The number of excess UTF-8 bytes in this row that go beyond all the charWidths.
+     */
+    private static int charWidthsToByteWidths(ByteSlice row, int[] charWidths, boolean utf32CountingMode,
+            int[] byteWidths) {
+        int numCols = charWidths.length;
+        if (byteWidths.length != numCols) {
+            throw new IllegalArgumentException(
+                    String.format("Expected charWidths.length (%d) == byteWidths.length (%d)",
+                            charWidths.length, byteWidths.length));
+        }
+        final MutableInt charCountResult = new MutableInt();
+        final byte[] data = row.data();
+        int start = row.begin();
+        int current = start;
+        int colIndex = 0;
+        int charCount = 0;
+        while (true) {
+            if (colIndex == numCols) {
+                // Excess bytes not claimed by any column
+                return row.end() - current;
+            }
+            if (charCount == charWidths[colIndex]) {
+                byteWidths[colIndex] = current - start;
+                start = current;
+                charCount = 0;
+                ++colIndex;
+                continue;
+            }
+
+            final byte ch = data[current];
+            final int utf8Length = ReaderUtil.getUtf8LengthAndCharLength(ch, row.end() - current, utf32CountingMode,
+                    charCountResult);
+            current += utf8Length;
+            charCount += charCountResult.intValue();
+        }
+    }
+}

--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -2099,8 +2099,10 @@ public class CsvReaderTest {
             expected = ColumnSet.of(
                     Column.ofRefs("Sym", "GOOG", null, null, "T", null, "Z"),
                     Column.ofRefs("Type", "Dividend", null, null, "Dividend", null, "Dividend"),
-                    Column.ofValues("Price", 0.25, Sentinels.NULL_DOUBLE, Sentinels.NULL_DOUBLE, 0.15, Sentinels.NULL_DOUBLE, 0.18),
-                    Column.ofValues("SecurityId", 200, Sentinels.NULL_INT, Sentinels.NULL_INT, 300, Sentinels.NULL_INT, 500));
+                    Column.ofValues("Price", 0.25, Sentinels.NULL_DOUBLE, Sentinels.NULL_DOUBLE, 0.15,
+                            Sentinels.NULL_DOUBLE, 0.18),
+                    Column.ofValues("SecurityId", 200, Sentinels.NULL_INT, Sentinels.NULL_INT, 300, Sentinels.NULL_INT,
+                            500));
         }
 
         final CsvSpecs specs = defaultCsvBuilder().hasFixedWidthColumns(true)

--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -26,6 +26,9 @@ import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.*;
 import java.lang.reflect.Array;
@@ -1853,12 +1856,6 @@ public class CsvReaderTest {
     public void colnumPassedThrough() throws CsvReaderException {
         final String input = "" + "Col1,Col2,Col3\n" + "1,2,3\n" + "4,5,6\n" + "7,8,9\n";
 
-        final ColumnSet expected =
-                ColumnSet.of(
-                        Column.ofValues("Col1", 1, 4, 7),
-                        Column.ofValues("Col2", 2, 5, 8),
-                        Column.ofValues("Col3", 3, 6, 9));
-
         final InputStream inputStream = toInputStream(input);
         final CsvSpecs specs = defaultCsvSpecs();
         final SinkFactory sinkFactory = makeBlackholeSinkFactory();
@@ -1871,6 +1868,320 @@ public class CsvReaderTest {
         Assertions.assertThat(bh0Num).isEqualTo(0);
         Assertions.assertThat(bh1Num).isEqualTo(1);
         Assertions.assertThat(bh2Num).isEqualTo(2);
+    }
+
+    /**
+     * Addresses <a href="https://github.com/deephaven/deephaven-csv/issues/212"> A user requested that the library be
+     * able to read files like this.
+     */
+    @Test
+    public void bug212() throws CsvReaderException {
+        final String input =
+                ""
+                        + "NAME                     STATUS       AGE      LABELS\n"
+                        + "argo-events              Not Active   2y77d    app.kubernetes.io/instance=argo-events,kubernetes.io/metadata.name=argo-events\n"
+                        + "argo-workflows           Active       2y77d    app.kubernetes.io/instance=argo-workflows,kubernetes.io/metadata.name=argo-workflows\n"
+                        + "argocd                   Active       5y18d    kubernetes.io/metadata.name=argocd\n"
+                        + "beta                     Not Active   4y235d   kubernetes.io/metadata.name=beta\n";
+
+        final CsvSpecs specs = defaultCsvBuilder().hasFixedWidthColumns(true)
+                .ignoreSurroundingSpaces(true).build();
+
+        final ColumnSet expected = ColumnSet.of(
+                Column.ofRefs("NAME", "argo-events", "argo-workflows", "argocd", "beta"),
+                Column.ofRefs("STATUS", "Not Active", "Active", "Active", "Not Active"),
+                Column.ofRefs("AGE", "2y77d", "2y77d", "5y18d", "4y235d"),
+                Column.ofRefs("LABELS",
+                        "app.kubernetes.io/instance=argo-events,kubernetes.io/metadata.name=argo-events",
+                        "app.kubernetes.io/instance=argo-workflows,kubernetes.io/metadata.name=argo-workflows",
+                        "kubernetes.io/metadata.name=argocd",
+                        "kubernetes.io/metadata.name=beta"));
+
+        invokeTest(specs, input, expected);
+    }
+
+    @Test
+    public void simpleFixedColumnWidths() throws CsvReaderException {
+        final String input =
+                ""
+                        + "Sym   Type     Price   SecurityId\n"
+                        + "GOOG  Dividend 0.25    200\n"
+                        + "T     Dividend 0.15    300\n"
+                        + "Z     Dividend 0.18    500\n";
+
+        final ColumnSet expected =
+                ColumnSet.of(
+                        Column.ofRefs("Sym", "GOOG", "T", "Z"),
+                        Column.ofRefs("Type", "Dividend", "Dividend", "Dividend"),
+                        Column.ofValues("Price", 0.25, 0.15, 0.18),
+                        Column.ofValues("SecurityId", 200, 300, 500));
+
+        final CsvSpecs specs =
+                defaultCsvBuilder().hasFixedWidthColumns(true).ignoreSurroundingSpaces(true).build();
+
+        invokeTest(specs, input, expected);
+    }
+
+    /**
+     * We allow data fields to fill the whole cell, without a padding character
+     * 
+     * @throws CsvReaderException
+     */
+    @Test
+    public void fixedColumnWidthsFullCell() throws CsvReaderException {
+        final String input =
+                ""
+                        + "Sym   Type     Price   SecurityId\n"
+                        + "GOOGLEDividend!0.25    200\n"
+                        + "T     Dividend 0.15    300\n";
+
+        final ColumnSet expected =
+                ColumnSet.of(
+                        Column.ofRefs("Sym", "GOOGLE", "T"),
+                        Column.ofRefs("Type", "Dividend!", "Dividend"),
+                        Column.ofValues("Price", 0.25, 0.15),
+                        Column.ofValues("SecurityId", 200, 300));
+
+        final CsvSpecs specs =
+                defaultCsvBuilder().hasFixedWidthColumns(true).ignoreSurroundingSpaces(true).build();
+        invokeTest(specs, input, expected);
+    }
+
+    /**
+     * As usual, we allow rows to be short
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void fixedColumnWidthsShortRows(boolean allowMissingColumns) throws CsvReaderException {
+        final String input =
+                ""
+                        + "Sym   Type     Price   SecurityId\n"
+                        + "GOOG\n"
+                        + "T     Dividend 0.15    300\n"
+                        + "Z     Dividend 0.18    500\n"
+                        + "QQQ   Coupon\n";
+
+        final ColumnSet expected =
+                ColumnSet.of(
+                        Column.ofRefs("Sym", "GOOG", "T", "Z", "QQQ"),
+                        Column.ofRefs("Type", null, "Dividend", "Dividend", "Coupon"),
+                        Column.ofValues("Price", Sentinels.NULL_DOUBLE, 0.15, 0.18, Sentinels.NULL_DOUBLE),
+                        Column.ofValues("SecurityId", Sentinels.NULL_INT, 300, 500, Sentinels.NULL_INT));
+
+        final CsvSpecs specs = defaultCsvBuilder().hasFixedWidthColumns(true)
+                .ignoreSurroundingSpaces(true).allowMissingColumns(allowMissingColumns).build();
+
+        if (allowMissingColumns) {
+            invokeTest(specs, input, expected);
+        } else {
+            Assertions.assertThatThrownBy(() -> invokeTest(specs, input, expected))
+                    .hasRootCauseMessage("Row 2 has too few columns (expected 4)");
+        }
+    }
+
+    /**
+     * If there is no header row, the caller needs to specify column widths.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void noHeaderRowRequiresFixColumnWidthsSpecified(boolean specifyColumnWidths) throws CsvReaderException {
+        final String input =
+                ""
+                        + "GOOG  Dividend 0.25    200\n"
+                        + "T     Dividend 0.15    300\n"
+                        + "Z     Coupon   0.18    500\n";
+
+        final ColumnSet expected =
+                ColumnSet.of(
+                        Column.ofRefs("Column1", "GOOG", "T", "Z"),
+                        Column.ofRefs("Column2", "Dividend", "Dividend", "Coupon"),
+                        Column.ofValues("Column3", 0.25, 0.15, 0.18),
+                        Column.ofValues("Column4", 200, 300, 500));
+
+        final CsvSpecs.Builder specsBase = defaultCsvBuilder().hasFixedWidthColumns(true).hasHeaderRow(false)
+                .ignoreSurroundingSpaces(true);
+
+        if (specifyColumnWidths) {
+            final CsvSpecs specs = specsBase.fixedColumnWidths(Arrays.asList(6, 9, 8, 3)).build();
+            invokeTest(specs, input, expected);
+        } else {
+            final CsvSpecs specs = specsBase.build();
+            Assertions.assertThatThrownBy(() -> invokeTest(specs, input, expected))
+                    .hasMessage("Can't proceed because hasHeaderRow is false but fixedColumnWidths is unspecified");
+        }
+    }
+
+    /**
+     * If there is no header row, the caller may specify column names. Otherwise synthetic column names will be
+     * generated.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void columnNamesMayBeSpecified(boolean specifyColumnNames) throws CsvReaderException {
+        final String input =
+                ""
+                        + "GOOG  Dividend 0.25    200\n"
+                        + "T     Dividend 0.15    300\n"
+                        + "Z     Coupon   0.18    500\n";
+
+        final String[] expectedColumnNames = specifyColumnNames ? new String[] {"Sym", "Type", "Price", "SecurityId"}
+                : new String[] {"Column1", "Column2", "Column3", "Column4"};
+
+        final ColumnSet expected =
+                ColumnSet.of(
+                        Column.ofRefs(expectedColumnNames[0], "GOOG", "T", "Z"),
+                        Column.ofRefs(expectedColumnNames[1], "Dividend", "Dividend", "Coupon"),
+                        Column.ofValues(expectedColumnNames[2], 0.25, 0.15, 0.18),
+                        Column.ofValues(expectedColumnNames[3], 200, 300, 500));
+
+        CsvSpecs.Builder specsBuilder = defaultCsvBuilder().hasFixedWidthColumns(true).hasHeaderRow(false)
+                .ignoreSurroundingSpaces(true).fixedColumnWidths(Arrays.asList(6, 9, 8, 3));
+
+        if (specifyColumnNames) {
+            specsBuilder = specsBuilder.headers(Arrays.asList(expectedColumnNames));
+        }
+
+        invokeTest(specsBuilder.build(), input, expected);
+    }
+
+    /**
+     * All six Unicode characters ♡♥❥❦◑╳ are in the Basic Multilingual Plane and can all be represented with a single
+     * Java char. Therefore, they are counted the same with both counting conventions.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void countsBMPCharactersTheSame(boolean useUtf32CountingConvention) throws CsvReaderException {
+        final String input =
+                ""
+                        + "Sym   Type     Price   SecurityId\n"
+                        + "♡♥❥❦◑╳Dividend 0.15    300\n"
+                        + "Z     Dividend 0.18    500\n";
+
+        final ColumnSet expected =
+                ColumnSet.of(
+                        Column.ofRefs("Sym", "♡♥❥❦◑╳", "Z"),
+                        Column.ofRefs("Type", "Dividend", "Dividend"),
+                        Column.ofValues("Price", 0.15, 0.18),
+                        Column.ofValues("SecurityId", 300, 500));
+
+        final CsvSpecs specs = defaultCsvBuilder().hasFixedWidthColumns(true)
+                .ignoreSurroundingSpaces(true).useUtf32CountingConvention(useUtf32CountingConvention).build();
+
+        invokeTest(specs, input, expected);
+    }
+
+    /**
+     * All six Unicode characters 🥰😻🧡💓💕💖 are _outside_ the Basic Multilingual Plane and all are represented with
+     * two Java chars. The Sym column has a width of six. They will fit in the "Sym" column if the caller uses UTF-32
+     * counting convention. They will not fit in the column if the caller uses the UTF-16 counting convention (because
+     * it takes 12 Java chars to express them).
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void countsNonBMPCharactersDifferently(boolean useUtf32CountingConvention) throws CsvReaderException {
+        final String input =
+                ""
+                        + "Sym   Type\n"
+                        + "🥰😻🧡💓💕💖Dividend\n"
+                        + "Z     Dividend\n";
+
+        final ColumnSet expected;
+
+        if (useUtf32CountingConvention) {
+            expected = ColumnSet.of(
+                    Column.ofRefs("Sym", "🥰😻🧡💓💕💖", "Z"),
+                    Column.ofRefs("Type", "Dividend", "Dividend"));
+        } else {
+            expected = ColumnSet.of(
+                    Column.ofRefs("Sym", "🥰😻🧡", "Z"),
+                    Column.ofRefs("Type", "💓💕💖Dividend", "Dividend"));
+        }
+
+        final CsvSpecs specs = defaultCsvBuilder().hasFixedWidthColumns(true)
+                .ignoreSurroundingSpaces(true).useUtf32CountingConvention(useUtf32CountingConvention).build();
+
+        invokeTest(specs, input, expected);
+    }
+
+    /**
+     * Using Unicode characters as column headers. We give one column a header with characters from the BMP and one with
+     * characters outside the BMP and show how the behavior differs depending on the useUtf32CountingConvention flag.
+     * ╔═╗ All six Unicode characters 🥰😻🧡💓💕💖 are _outside_ the Basic Multilingual Plane and all are represented
+     * with two Java chars. The Sym column has a width of six. They will fit in the "Sym" column if the caller uses
+     * UTF-32 counting convention. They will not fit in the column if the caller uses the UTF-16 counting convention
+     * (because it takes 12 Java chars to express them).
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void unicodeColumnHeaders(boolean useUtf32CountingConvention) throws CsvReaderException {
+        // In the UTF-32 counting convention, this is a column of width 4 (three Unicode characters plus the space)
+        // followed by a column of width 5. The first cell of the data would therefore be "abc", and the next cell
+        // would be "def".
+
+        // In the UTF-16 counting convention, this is a column of width 7 (six UTF-16 units plus the space)
+        // followed by a column of width 5. The first cell of the data would therefore be "abc def" and the next
+        // cell woult be "gh".
+        final String input =
+                ""
+                        + "🥰😻🧡 ╔═╤═╗\n"
+                        + "abc defgh\n";
+
+        final ColumnSet expected;
+
+        if (useUtf32CountingConvention) {
+            expected = ColumnSet.of(
+                    Column.ofRefs("🥰😻🧡", "abc"),
+                    Column.ofRefs("╔═╤═╗", "defgh"));
+        } else {
+            expected = ColumnSet.of(
+                    Column.ofRefs("🥰😻🧡", "abc def"),
+                    Column.ofRefs("╔═╤═╗", "gh"));
+        }
+
+        final CsvSpecs specs = defaultCsvBuilder().hasFixedWidthColumns(true)
+                .ignoreSurroundingSpaces(true).useUtf32CountingConvention(useUtf32CountingConvention).build();
+
+        invokeTest(specs, input, expected);
+    }
+
+    /**
+     * If the library is configured for the UTF-16 counting convention, and there is only one unit of space left in the
+     * field, and the next character is a character outside the Basic Multilingual Plane that requires two units, the
+     * library will include that character in the next field rather than this one.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void brokenSurrogatePair(boolean useUtf32CountingConvention) throws CsvReaderException {
+        // This test has a column of width 3 (three characters plus the space)
+        // followed by a column of width 2.
+        //
+        // In the UTF-32 counting convention, the first column will get "🥰😻 " and the second column will
+        // get "🧡💓". We turn off ignoreSurroundingSpaces to highlight how this is counted.
+        //
+        // In the UTF-16 counting convention, the first column will get 🥰 (because 🥰😻 uses characters
+        // outside the Basic Multilingual Plane and takes four units to represent, but the first field
+        // only has space for three). The next column will get "😻 🧡💓" (the rest of the row).
+        final String input =
+                ""
+                        + "C1 C2\n"
+                        + "🥰😻 🧡💓\n";
+
+        final ColumnSet expected;
+
+        if (useUtf32CountingConvention) {
+            expected = ColumnSet.of(
+                    Column.ofRefs("C1", "🥰😻 "),
+                    Column.ofRefs("C2", "🧡💓"));
+        } else {
+            expected = ColumnSet.of(
+                    Column.ofRefs("C1", "🥰"),
+                    Column.ofRefs("C2", "😻 🧡💓"));
+        }
+
+        final CsvSpecs specs = defaultCsvBuilder().hasFixedWidthColumns(true)
+                .ignoreSurroundingSpaces(false).useUtf32CountingConvention(useUtf32CountingConvention).build();
+
+        invokeTest(specs, input, expected);
     }
 
     private static final class RepeatingInputStream extends InputStream {


### PR DESCRIPTION
This PR depends on https://github.com/deephaven/deephaven-csv/pull/219 and should not be merged until that one is.

Until then the changes in this PR will look like they also include the changes from https://github.com/deephaven/deephaven-csv/pull/219, but that will go away once the other PR has been merged.

This PR resolves https://github.com/deephaven/deephaven-csv/issues/212

Perhaps the most controversial idea here is the flag that controls how characters are counted. Should they be UTF-32 code points or the number of characters Java would see as `String.length`? There's no difference until you go outside the Unicode Basic Multilingual Plane. But once outside that plane, Unicode code points require two Java `char` rather than one.

The question is, what does the user intend? Should a string like `🥰😻🧡💓💕💖` represent a width of six (because it is six Unicode code points) or a width of twelve (because the Java string representing it would have length 12).

I think in some sense the question has no right answer, so we have a flag `CsvSpecs.useUtf32CountingConvention` to make it go one way or the other.

Also I need to add a couple more tests that I forgot to do (e.g. for explicitly specifying column widths rather than inferring them, and a file that has no column headers, etc).


