### PR TITLE
Update to Central Portal publishing with gradle-maven-publish-plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,10 +38,13 @@ jobs:
       - name: Publish
         # Note: even though we specify org.gradle.parallel=false in our CI gradle.properties, we want to be explicit
         # here about no parallelism to ensure we don't create disjointed staging repositories.
-        run: ./gradlew --no-parallel assemble publish
+        # Edit: unclear if above note is still possible with the new portal API / plugin implementation.
+        # Note: --no-configuration-cache is documented as necessary due https://github.com/gradle/gradle/issues/22779
+        # from https://vanniktech.github.io/gradle-maven-publish-plugin/central/#uploading-with-automatic-publishing
+        run: ./gradlew --no-parallel --no-configuration-cache assemble publishToMavenCentral
         env:
-          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.CI_AT_DEEPHAVEN_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.CI_AT_DEEPHAVEN_PASSWORD }}
           ORG_GRADLE_PROJECT_signingRequired: true

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,4 +14,7 @@ dependencies {
     implementation('com.diffplug.spotless:spotless-plugin-gradle:7.0.4') {
         because('needed by plugin java-coding-conventions')
     }
+    implementation('com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.33.0') {
+        because('needed by plugin java-publishing-conventions')
+    }
 }

--- a/buildSrc/src/main/groovy/io.deephaven.csv.java-publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.csv.java-publishing-conventions.gradle
@@ -1,12 +1,13 @@
 plugins {
     id 'java'
     id 'signing'
-    id 'maven-publish'
+    id 'com.vanniktech.maven.publish'
 }
 
 java {
-    withJavadocJar()
-    withSourcesJar()
+    // https://github.com/vanniktech/gradle-maven-publish-plugin/issues/1028
+    // withSourcesJar()
+    // withJavadocJar()
 }
 
 def developerId = 'deephaven'
@@ -27,61 +28,48 @@ def scmUrl = 'https://github.com/deephaven/deephaven-csv'
 def scmConnection = 'scm:git:git://github.com/deephaven/deephaven-csv.git'
 def scmDevConnection = 'scm:git:ssh://github.com/deephaven/deephaven-csv.git'
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-            artifactId = archivesBaseName
-            pom {
-                name = archivesBaseName
-                description = project.description
-                url = projectUrl
-                organization {
-                    name = orgName
-                    url = orgUrl
-                }
-                licenses {
-                    license {
-                        name = licenseName
-                        url = licenseUrl
-                    }
-                }
-                scm {
-                    url = scmUrl
-                    connection = scmConnection
-                    developerConnection = scmDevConnection
-                }
-                issueManagement {
-                    system = issuesSystem
-                    url = issuesUrl
-                }
-                developers {
-                    developer {
-                        id = developerId
-                        name = developerName
-                        email = developerEmail
-                        organization = orgName
-                        organizationUrl = orgUrl
-                    }
-                }
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+    // We only need to override artifactId; groupId (1st argument), version (3rd argument) will be inferred
+    coordinates(null, archivesBaseName, null)
+    pom {
+        name = archivesBaseName
+        description = project.description
+        url = projectUrl
+        organization {
+            name = orgName
+            url = orgUrl
+        }
+        licenses {
+            license {
+                name = licenseName
+                url = licenseUrl
             }
         }
-    }
-    repositories {
-        maven {
-            name = 'ossrh'
-            // ossrhUsername, ossrhPassword
-            credentials(PasswordCredentials)
-            def releasesRepoUrl = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+        scm {
+            url = scmUrl
+            connection = scmConnection
+            developerConnection = scmDevConnection
+        }
+        issueManagement {
+            system = issuesSystem
+            url = issuesUrl
+        }
+        developers {
+            developer {
+                id = developerId
+                name = developerName
+                email = developerEmail
+                organization = orgName
+                organizationUrl = orgUrl
+            }
         }
     }
 }
 
 signing {
     required = "true" == findProperty('signingRequired')
-    sign publishing.publications.mavenJava
     String signingKey = findProperty('signingKey')
     String signingPassword = findProperty('signingPassword')
     if (signingKey != null && signingPassword != null) {


### PR DESCRIPTION
The pom-default.xml is exactly the same.

The module.json is _almost_ the same, with the one difference being the removal of the javadocElements variant. It is unclear if this has any material difference. (The javadoc jar is still published.) Noted in https://github.com/vanniktech/gradle-maven-publish-plugin/issues/1028.

See https://vanniktech.github.io/gradle-maven-publish-plugin/