### PR TITLE
bug: Fix issue #249 (Infinite waiting during CsvReader.Read)

### DIFF
--- a/src/main/java/io/deephaven/csv/CsvSpecs.java
+++ b/src/main/java/io/deephaven/csv/CsvSpecs.java
@@ -517,7 +517,7 @@ public abstract class CsvSpecs {
         return true;
     }
 
-    private static boolean defaultTrim = false;
+    private static final boolean defaultTrim = false;
 
     /**
      * See {@link Builder#trim}.

--- a/src/main/java/io/deephaven/csv/densestorage/QueueNode.java
+++ b/src/main/java/io/deephaven/csv/densestorage/QueueNode.java
@@ -24,7 +24,7 @@ public final class QueueNode<TARRAY> {
     /** Readers and writers of this field have arranged to synchronize with each other. */
     public QueueNode<TARRAY> next;
     /**
-     * Whether a reader has already observed the {@link QueueNode#next} field transitioning from non-null to null.
+     * Whether a reader has already observed the {@link QueueNode#next} field transitioning from null to non-null.
      */
     private boolean observed;
 

--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -326,7 +326,6 @@ public class CsvReaderTest {
         invokeTest(defaultCsvBuilder().parsers(Parsers.DEFAULT).build(), input, expected);
     }
 
-
     @Test
     public void validates() {
         final String lengthyMessage = "CsvSpecs failed validation for the following reasons: "

--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -278,12 +278,12 @@ public class CsvReaderTest {
     @Test
     @Timeout(value = 10)
     public void bug249() throws CsvReaderException {
-        assert(DenseStorageConstants.LARGE_THRESHOLD > 10);
+        assert (DenseStorageConstants.LARGE_THRESHOLD > 10);
 
         final StringBuilder smallStringBuilder = new StringBuilder();
         final StringBuilder bigStringBuilder = new StringBuilder();
 
-        // Make a string small enough that the DenseStorageWriter will write it to the normal byteWriter
+        // Make a string small enough that the DenseStorageWriter will write it to the normal byteWriter.
         // -10 for a little less
         for (int i = 0; i != DenseStorageConstants.LARGE_THRESHOLD - 10; ++i) {
             smallStringBuilder.append('s');
@@ -299,10 +299,12 @@ public class CsvReaderTest {
         final String bigString = bigStringBuilder.toString();
 
         // approximate number of small strings that will fill a block. +10 for a little extra
-        final int numSmallStringsThatWillFillABlock = DenseStorageConstants.PACKED_QUEUE_SIZE / smallString.length() + 10;
+        final int numSmallStringsThatWillFillABlock =
+                DenseStorageConstants.PACKED_QUEUE_SIZE / smallString.length() + 10;
 
         // Multiply by the number of blocks needed to trigger a deadlock. +10 for a little extra
-        final int numSmallStrings = numSmallStringsThatWillFillABlock * DenseStorageConstants.MAX_UNOBSERVED_BLOCKS + 10;
+        final int numSmallStrings =
+                numSmallStringsThatWillFillABlock * DenseStorageConstants.MAX_UNOBSERVED_BLOCKS + 10;
 
         // Dynamically build the column
         List<String> colData = new ArrayList<>();


### PR DESCRIPTION
TL;DR classic deadlock between writer and reader because code is trying to be clever.

Deep Background:

an early phase of processing looks like this:
- read a line from the file
- split that line into cells
- push each cell into a separate queue, to be processed by a column reader running on its own thread

That is, there is one queue for each column.

Furthermore each queue is actually composed of three subqueues:
- a "normal" writer, where "smaller" strings are packed into blocks and then appended to a queue when the block is full
- a "large" writer, where "larger" strings are gathered; references to these strings are gathered in a different kind of block, and appended to a queue, when the block is full
- a "control" writer, which contains an integer indicating which writer a string went into: normal or large. This is used so the reader can recover these strings in the proper order by reading from the normal or large queue, respectively. These control values are also packed into blocks and appended to a queue when the block is full.


There is also flow control logic which blocks the writer if it gets too far ahead of the reader. This flow control logic is where the bug happened.

Steps to reproduce:
- first write a large string to your large string writer, triggering the first clause in the code below, in such a way that neither action inherently causes a flush, so both `fdata` and `fctrl` are false. Now you have unflushed data in your `largeByteArrayWriter` and an unflushed control item in your `controlWriter`
- then write numerous small strings to your small string writer, triggering the "else" clause in this code, taking care that you fill the `byteWriter` but not the `controlWriter`. This will cause `fdata` to be true but `fctrl` to be false.
- This leads to the situation where `byteWriter` has been flushed (because it filled), and `controlWriter` has been flushed (because of the `else if (fdata)`) but no one has flushed `largeByteArrayWriter`.
- If you continue to call this in the same way you can keep flushing `byteWriter` and `controlWriter` but no one will flush `largeByteArrayWriter`
- On the reader side, the flush of the `controlWriter` leads to the reader reading the control word telling it to expect a large string. But because the writer never flushes `largeByteArrayWriter`, the reader hangs forever waiting for a large string that will never come.

The fix is when any of the queues flush, flush them all.

```
        if (size >= DenseStorageConstants.LARGE_THRESHOLD) {
            final byte[] data = new byte[size];
            bs.copyTo(data, 0);
            fdata = largeByteArrayWriter.addByteArray(data);
            fctrl = controlWriter.addInt(DenseStorageConstants.LARGE_BYTE_ARRAY_SENTINEL);
        } else {
            fdata = byteWriter.addBytes(bs);
            fctrl = controlWriter.addInt(size);
        }
        // [lengthy comment elided]
        if (fctrl) {
            byteWriter.flush();
            largeByteArrayWriter.flush();
        } else if (fdata) {
            controlWriter.flush();
        }
```
