### PR TITLE
fix: Unclosed Quotation Mark deadlocks in nonconcurrent case (#251)

### DIFF
--- a/src/main/java/io/deephaven/csv/reading/cells/DelimitedCellGrabber.java
+++ b/src/main/java/io/deephaven/csv/reading/cells/DelimitedCellGrabber.java
@@ -113,7 +113,7 @@ public final class DelimitedCellGrabber implements CellGrabber {
                 }
             }
             final byte ch = buffer[offset++];
-            // Maintain a correct row number. This is somehat tricky.
+            // Maintain a correct row number. This is somewhat tricky.
             if (ch == '\r') {
                 ++physicalRowNum;
                 prevCharWasCarriageReturn = true;


### PR DESCRIPTION
TL;DR classic deadlock between writer and reader because code is trying to be clever.

Explanation:

The code in `CsvReader.commonReadLogic` tries to be clever by using an Executor for both the nonconcurrent and concurrent cases. In the concurrent case it uses a fixed thread pool. In the nonconcurrent case it uses a `DirectExecutor`.

However in the nonconcurrent case it does not correctly handle this scenario:
- Run the writer on the `DirectExecutor`. The writer fails with an exception because of the lack of closing quote.
- Next, run the reader on the `DirectExecutor`. This reader waits forever for input from the writer; this input will never come.

When posting jobs to the DirectExecutor, it would be more correct to observe the resulting future to see if it completed successfully or not, before moving on to posting the next job. However this complicates the code because you do not want to do so when using a concurrent executor. Put another way, in the concurrent case, for the sake of concurrency you want to post all the jobs first, and **then** observe all their futures.

It is cleaner to just separate this code into two cases and not even use an Executor for the nonconcurrent case.

Fixes https://github.com/deephaven/deephaven-csv/issues/251