### PR TITLE
chore: Update gradle-maven-publish-plugin to 0.34.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,9 +39,7 @@ jobs:
         # Note: even though we specify org.gradle.parallel=false in our CI gradle.properties, we want to be explicit
         # here about no parallelism to ensure we don't create disjointed staging repositories.
         # Edit: unclear if above note is still possible with the new portal API / plugin implementation.
-        # Note: --no-configuration-cache is documented as necessary due https://github.com/gradle/gradle/issues/22779
-        # from https://vanniktech.github.io/gradle-maven-publish-plugin/central/#uploading-with-automatic-publishing
-        run: ./gradlew --no-parallel --no-configuration-cache assemble publishToMavenCentral
+        run: ./gradlew --no-parallel assemble publishToMavenCentral
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation('com.diffplug.spotless:spotless-plugin-gradle:7.1.0') {
         because('needed by plugin java-coding-conventions')
     }
-    implementation('com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.33.0') {
+    implementation('com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.34.0') {
         because('needed by plugin java-publishing-conventions')
     }
 }


### PR DESCRIPTION
This removes the need for the `--no-configuration-cache` publishing workaround, see https://github.com/vanniktech/gradle-maven-publish-plugin/pull/1071.

See https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.34.0