### PR TITLE
fix: DH-21298: Factor out test utility classes

### DIFF
--- a/src/test/java/io/deephaven/csv/testutil/Blackhole.java
+++ b/src/test/java/io/deephaven/csv/testutil/Blackhole.java
@@ -1,0 +1,30 @@
+package io.deephaven.csv.testutil;
+
+import io.deephaven.csv.sinks.Sink;
+import io.deephaven.csv.sinks.Source;
+
+public class Blackhole<TARRAY> implements Sink<TARRAY>, Source<TARRAY> {
+    private final int colNum;
+
+    public Blackhole(int colNum) {
+        this.colNum = colNum;
+    }
+
+    @Override
+    public void write(TARRAY src, boolean[] isNull, long destBegin, long destEnd, boolean appending) {
+        // Do nothing.
+    }
+
+    /**
+     * For the sake of one of our unit tests, we return the colNum as our underlying.
+     */
+    @Override
+    public Object getUnderlying() {
+        return colNum;
+    }
+
+    @Override
+    public void read(TARRAY dest, boolean[] isNull, long srcBegin, long srcEnd) {
+        // Do nothing.
+    }
+}

--- a/src/test/java/io/deephaven/csv/testutil/Column.java
+++ b/src/test/java/io/deephaven/csv/testutil/Column.java
@@ -1,0 +1,83 @@
+package io.deephaven.csv.testutil;
+
+import io.deephaven.csv.CsvReaderTest;
+
+import java.lang.reflect.Array;
+
+public final class Column<TARRAY> {
+    private final String name;
+    private final TARRAY values;
+    private final int size;
+    private final Class<?> reinterpretedType;
+
+    public static Column<byte[]> ofValues(final String name, final byte... values) {
+        return ofArray(name, values, values.length);
+    }
+
+    public static Column<short[]> ofValues(final String name, final short... values) {
+        return ofArray(name, values, values.length);
+    }
+
+    public static Column<int[]> ofValues(final String name, final int... values) {
+        return ofArray(name, values, values.length);
+    }
+
+    public static Column<long[]> ofValues(final String name, final long... values) {
+        return ofArray(name, values, values.length);
+    }
+
+    public static Column<float[]> ofValues(final String name, final float... values) {
+        return ofArray(name, values, values.length);
+    }
+
+    public static Column<double[]> ofValues(final String name, final double... values) {
+        return ofArray(name, values, values.length);
+    }
+
+    public static Column<char[]> ofValues(final String name, final char... values) {
+        return ofArray(name, values, values.length);
+    }
+
+    public static <T> Column<T[]> ofRefs(final String name, final T... values) {
+        return ofArray(name, values, values.length);
+    }
+
+    public static <TARRAY> Column<TARRAY> ofArray(final String name, final TARRAY values, int size) {
+        return new Column<>(name, values, size);
+    }
+
+    private Column(final String name, final TARRAY values, int size) {
+        this(name, values, size, values.getClass().getComponentType());
+    }
+
+    private Column(final String name, final TARRAY values, int size, Class<?> reinterpretedType) {
+        this.name = name;
+        this.values = values;
+        this.size = size;
+        this.reinterpretedType = reinterpretedType;
+    }
+
+    public Column<TARRAY> reinterpret(Class<?> reinterpretedType) {
+        return new Column<>(name, values, size, reinterpretedType);
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public Class<?> elementType() {
+        return values.getClass().getComponentType();
+    }
+
+    public Class<?> reinterpretedType() {
+        return reinterpretedType;
+    }
+
+    public Object getItem(int index) {
+        return Array.get(values, index);
+    }
+}

--- a/src/test/java/io/deephaven/csv/testutil/ColumnSet.java
+++ b/src/test/java/io/deephaven/csv/testutil/ColumnSet.java
@@ -1,0 +1,73 @@
+package io.deephaven.csv.testutil;
+
+import io.deephaven.csv.CsvReaderTest;
+import io.deephaven.csv.util.Renderer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+
+public final class ColumnSet {
+    public static final ColumnSet NONE = new ColumnSet(new Column[0], 0);
+
+    private final Column<?>[] columns;
+    private final int columnSize;
+
+    public static ColumnSet of(Column<?>... columns) {
+        if (columns.length == 0) {
+            throw new RuntimeException("Empty column set is not permitted");
+        }
+        final int c0Size = columns[0].size();
+        for (int ii = 1; ii < columns.length; ++ii) { // Deliberately starting at 1.
+            final int ciiSize = columns[ii].size();
+            if (ciiSize != c0Size) {
+                throw new RuntimeException(
+                        String.format(
+                                "Column %d (size %d) has a different size than column 0 (size %d)",
+                                ii, ciiSize, c0Size));
+            }
+        }
+        return new ColumnSet(columns, c0Size);
+    }
+
+    private ColumnSet(Column<?>[] columns, int columnSize) {
+        this.columns = columns;
+        this.columnSize = columnSize;
+    }
+
+    public Column<?>[] getColumns() {
+        return columns;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        final List<Column<?>> colList = Arrays.asList(columns);
+
+        final BiFunction<Class<?>, Class<?>, String> renderType =
+                (etype, rtype) -> {
+                    if (etype == rtype) {
+                        return etype.getCanonicalName();
+                    }
+                    return etype.getCanonicalName() + "->" + rtype.getCanonicalName();
+                };
+
+        Renderer.renderList(
+                sb,
+                colList,
+                ",",
+                col -> String.format(
+                        "%s(%s)",
+                        col.name(), renderType.apply(col.elementType(), col.reinterpretedType())));
+        for (int jj = 0; jj < columnSize; ++jj) {
+            final int jjFinal = jj;
+            sb.append('\n');
+            Renderer.renderList(sb, colList, ",", col -> safeToString(col.getItem(jjFinal)));
+        }
+        return sb.toString();
+    }
+
+    private static String safeToString(Object o) {
+        return o == null ? "(null)" : o.toString();
+    }
+}

--- a/src/test/java/io/deephaven/csv/testutil/CsvTestUtil.java
+++ b/src/test/java/io/deephaven/csv/testutil/CsvTestUtil.java
@@ -1,0 +1,219 @@
+package io.deephaven.csv.testutil;
+
+import io.deephaven.csv.CsvSpecs;
+import io.deephaven.csv.parsers.DataType;
+import io.deephaven.csv.reading.CsvReader;
+import io.deephaven.csv.sinks.SinkFactory;
+import io.deephaven.csv.util.CsvReaderException;
+import org.apache.commons.io.input.ReaderInputStream;
+import org.assertj.core.api.Assertions;
+
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class CsvTestUtil {
+    public static CsvSpecs defaultCsvSpecs() {
+        return defaultCsvBuilder().build();
+    }
+
+    public static CsvSpecs.Builder defaultCsvBuilder() {
+        return CsvSpecs.builder().ignoreSurroundingSpaces(true).allowMissingColumns(true);
+    }
+
+    public static void invokeTest(final CsvSpecs specs, final String input, final ColumnSet expected)
+            throws CsvReaderException {
+        invokeTest(specs, input, expected, makeMySinkFactory(), null);
+    }
+
+    public static void invokeTest(final CsvSpecs specs, final String input, final ColumnSet expected,
+            final SinkFactory sinkFactory, MakeCustomColumn makeCustomColumn)
+            throws CsvReaderException {
+        invokeTest(specs, toInputStream(input), expected, sinkFactory, makeCustomColumn);
+    }
+
+    public static void invokeTest(final CsvSpecs specs, final InputStream inputStream, final ColumnSet expected,
+            final SinkFactory sinkFactory, MakeCustomColumn makeCustomColumn)
+            throws CsvReaderException {
+        final CsvReader.Result result = parse(specs, inputStream, sinkFactory);
+        final ColumnSet actual = toColumnSet(result, makeCustomColumn);
+        final String expectedToString = expected.toString();
+        final String actualToString = actual.toString();
+        Assertions.assertThat(actualToString).isEqualTo(expectedToString);
+    }
+
+    /**
+     * Parses {@code inputStream} according to the specifications of {@code csvReader}.
+     *
+     * @param inputStream the input stream.
+     * @return The parsed data
+     * @throws CsvReaderException If any sort of failure occurs.
+     */
+    public static CsvReader.Result parse(final CsvSpecs specs, final InputStream inputStream)
+            throws CsvReaderException {
+        return parse(specs, inputStream, makeMySinkFactory());
+    }
+
+    /**
+     * Parses {@code inputStream} according to the specifications of {@code csvReader}.
+     *
+     *
+     * @param inputStream the input stream.
+     * @return The parsed data
+     * @throws CsvReaderException If any sort of failure occurs.
+     */
+    public static CsvReader.Result parse(final CsvSpecs specs, final InputStream inputStream,
+            final SinkFactory sinkFactory)
+            throws CsvReaderException {
+        return CsvReader.read(specs, inputStream, sinkFactory);
+    }
+
+    /** Convert String to InputStream */
+    public static InputStream toInputStream(final String input) {
+        final StringReader reader = new StringReader(input);
+        return new ReaderInputStream(reader, StandardCharsets.UTF_8);
+    }
+
+    /***
+     * Converts the {@link CsvReader.Result} to a {@link ColumnSet}.
+     */
+    public static ColumnSet toColumnSet(final CsvReader.Result result, MakeCustomColumn makeCustomColumn) {
+        final int numCols = result.numCols();
+        final CsvReader.ResultColumn[] resultColumns = result.columns();
+
+        final Column<?>[] columns = new Column[numCols];
+        final int sizeAsInt = Math.toIntExact(result.numRows());
+
+        for (int ii = 0; ii < numCols; ++ii) {
+            final CsvReader.ResultColumn rc = resultColumns[ii];
+            columns[ii] = makeColumn(rc.name(), rc.dataType(), rc.data(), sizeAsInt, makeCustomColumn);
+        }
+        return ColumnSet.of(columns);
+    }
+
+    private static Column<?> makeColumn(final String name, final DataType dataType, final Object col,
+            final int size, MakeCustomColumn makeCustomColumn) {
+        switch (dataType) {
+            case BOOLEAN_AS_BYTE: {
+                return Column.ofArray(name, col, size).reinterpret(boolean.class);
+            }
+
+            case BYTE:
+            case SHORT:
+            case INT:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+            case CHAR:
+            case STRING: {
+                return Column.ofArray(name, col, size);
+            }
+
+            case DATETIME_AS_LONG:
+            case TIMESTAMP_AS_LONG: {
+                return Column.ofArray(name, col, size).reinterpret(Instant.class);
+            }
+
+            case CUSTOM: {
+                if (makeCustomColumn == null) {
+                    throw new RuntimeException("Custom column not expected");
+                }
+                return makeCustomColumn.apply(name, col, size);
+            }
+
+            default: {
+                throw new RuntimeException("Unknown case " + dataType);
+            }
+        }
+    }
+
+    public static SinkFactory makeMySinkFactory() {
+        return SinkFactory.arrays(
+                Sentinels.NULL_BYTE,
+                Sentinels.NULL_SHORT,
+                Sentinels.NULL_INT,
+                Sentinels.NULL_LONG,
+                Sentinels.NULL_FLOAT,
+                Sentinels.NULL_DOUBLE,
+                Sentinels.NULL_BOOLEAN_AS_BYTE,
+                Sentinels.NULL_CHAR,
+                null,
+                Sentinels.NULL_DATETIME_AS_LONG,
+                Sentinels.NULL_TIMESTAMP_AS_LONG);
+    }
+
+    public static SinkFactory makeBlackholeSinkFactory() {
+        return SinkFactory.of(
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new);
+    }
+
+    public static SinkFactory makeBlackholeSinkFactoryWithFailingDoubleSink() {
+        return SinkFactory.of(
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                FailingSink::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new);
+    }
+
+    public static SinkFactory makeCooperatingSinkFactories(
+            Duration timeout, CountDownLatch incomingShutdownRequest,
+            CountDownLatch outgoingShutdownComplete) {
+        final CountDownLatch sinkReady = new CountDownLatch(1);
+        return SinkFactory.of(
+                Blackhole::new,
+                Blackhole::new,
+                colNum -> new ThrowingSink<>(sinkReady),
+                Blackhole::new,
+                Blackhole::new,
+                colNum -> new StubbornSink<>(timeout, sinkReady,
+                        incomingShutdownRequest, outgoingShutdownComplete),
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new);
+    }
+
+    public static SinkFactory makeBlackholeSinkFactoryWithSynchronizingDoubleSink(final int numParticipatingColumns,
+            final long thresholdSize) {
+        final SyncState ss = new SyncState(numParticipatingColumns, thresholdSize);
+        return SinkFactory.of(
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                colNum -> new SynchronizingSink<>(colNum, ss),
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new,
+                Blackhole::new);
+    }
+
+    public static String repeat(String x, int count) {
+        return Stream.generate(() -> x).limit(count).collect(Collectors.joining());
+    }
+}

--- a/src/test/java/io/deephaven/csv/testutil/FailingSink.java
+++ b/src/test/java/io/deephaven/csv/testutil/FailingSink.java
@@ -1,0 +1,30 @@
+package io.deephaven.csv.testutil;
+
+import io.deephaven.csv.sinks.Sink;
+import io.deephaven.csv.sinks.Source;
+
+public class FailingSink<TARRAY> implements Sink<TARRAY>, Source<TARRAY> {
+    private final int colNum;
+
+    public FailingSink(int colNum) {
+        this.colNum = colNum;
+    }
+
+    @Override
+    public void write(TARRAY src, boolean[] isNull, long destBegin, long destEnd, boolean appending) {
+        throw new RuntimeException("synthetic error for testing: out of memory");
+    }
+
+    /**
+     * For the sake of one of our unit tests, we return the colNum as our underlying.
+     */
+    @Override
+    public Object getUnderlying() {
+        return colNum;
+    }
+
+    @Override
+    public void read(TARRAY dest, boolean[] isNull, long srcBegin, long srcEnd) {
+        // Do nothing.
+    }
+}

--- a/src/test/java/io/deephaven/csv/testutil/MakeCustomColumn.java
+++ b/src/test/java/io/deephaven/csv/testutil/MakeCustomColumn.java
@@ -1,0 +1,5 @@
+package io.deephaven.csv.testutil;
+
+public interface MakeCustomColumn {
+    Column<?> apply(String name, Object column, int size);
+}

--- a/src/test/java/io/deephaven/csv/testutil/MyBigDecimalParser.java
+++ b/src/test/java/io/deephaven/csv/testutil/MyBigDecimalParser.java
@@ -1,0 +1,79 @@
+package io.deephaven.csv.testutil;
+
+import io.deephaven.csv.containers.ByteSlice;
+import io.deephaven.csv.parsers.DataType;
+import io.deephaven.csv.parsers.IteratorHolder;
+import io.deephaven.csv.parsers.Parser;
+import io.deephaven.csv.sinks.Sink;
+import io.deephaven.csv.tokenization.RangeTests;
+import io.deephaven.csv.util.CsvReaderException;
+import org.jetbrains.annotations.NotNull;
+
+import java.math.BigDecimal;
+
+public class MyBigDecimalParser implements Parser<BigDecimal[]> {
+    @NotNull
+    @Override
+    public ParserContext<BigDecimal[]> makeParserContext(GlobalContext gctx, int chunkSize) {
+        final MyReferenceTypeSink sink = new MyReferenceTypeSink();
+        return new ParserContext<>(sink, null, DataType.CUSTOM, new BigDecimal[chunkSize]);
+    }
+
+    @Override
+    public long tryParse(
+            GlobalContext gctx,
+            ParserContext<BigDecimal[]> pctx,
+            IteratorHolder ih,
+            long begin,
+            long end,
+            boolean appending)
+            throws CsvReaderException {
+        final boolean[] nulls = gctx.nullChunk();
+
+        final Sink<BigDecimal[]> sink = pctx.sink();
+        final BigDecimal[] values = pctx.valueChunk();
+
+        // Reusable buffer
+        char[] charData = new char[0];
+
+        long current = begin;
+        int chunkIndex = 0;
+        do {
+            if (chunkIndex == values.length) {
+                sink.write(values, nulls, current, current + chunkIndex, appending);
+                current += chunkIndex;
+                chunkIndex = 0;
+            }
+            if (current + chunkIndex == end) {
+                break;
+            }
+            if (gctx.isNullCell(ih)) {
+                nulls[chunkIndex++] = true;
+                continue;
+            }
+            final ByteSlice bs = ih.bs();
+            if (!RangeTests.isAscii(bs.data(), bs.begin(), bs.end())) {
+                break;
+            }
+
+            // Convert bytes to chars. Annoying.
+            if (charData.length < bs.size()) {
+                charData = new char[bs.size()];
+            }
+            int destIndex = 0;
+            for (int cur = bs.begin(); cur != bs.end(); ++cur) {
+                charData[destIndex++] = (char) bs.data()[cur];
+            }
+
+            try {
+                values[chunkIndex] = new BigDecimal(charData, 0, destIndex);
+            } catch (NumberFormatException ne) {
+                break;
+            }
+            nulls[chunkIndex] = false;
+            ++chunkIndex;
+        } while (ih.tryMoveNext());
+        sink.write(values, nulls, current, current + chunkIndex, appending);
+        return current + chunkIndex;
+    }
+}

--- a/src/test/java/io/deephaven/csv/testutil/MyReferenceTypeSink.java
+++ b/src/test/java/io/deephaven/csv/testutil/MyReferenceTypeSink.java
@@ -1,0 +1,41 @@
+package io.deephaven.csv.testutil;
+
+import io.deephaven.csv.sinks.Sink;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MyReferenceTypeSink<T> implements Sink<T[]> {
+    private final List<T> dest = new ArrayList<>();
+
+    @Override
+    public void write(
+            T[] src, boolean[] isNull, long destBegin, long destEnd, boolean appending) {
+        if (destBegin == destEnd) {
+            return;
+        }
+
+        final int size = Math.toIntExact(destEnd - destBegin);
+        if (appending) {
+            // If the new area starts beyond the end of the destination, pad the destination.
+            while (dest.size() < destBegin) {
+                dest.add(null);
+            }
+            for (int ii = 0; ii < size; ++ii) {
+                dest.add(isNull[ii] ? null : src[ii]);
+            }
+            return;
+        }
+
+        final int destBeginAsInt = Math.toIntExact(destBegin);
+        for (int ii = 0; ii < size; ++ii) {
+            dest.set(destBeginAsInt + ii, isNull[ii] ? null : src[ii]);
+        }
+    }
+
+    @Override
+    public Object getUnderlying() {
+        return dest;
+    }
+}

--- a/src/test/java/io/deephaven/csv/testutil/RepeatingInputStream.java
+++ b/src/test/java/io/deephaven/csv/testutil/RepeatingInputStream.java
@@ -1,0 +1,53 @@
+package io.deephaven.csv.testutil;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public final class RepeatingInputStream extends InputStream {
+    private byte[] data;
+    private final byte[] body;
+    private int bodyRepeatsRemaining;
+    private final byte[] tempBufferForRead;
+    private int offset;
+
+    public RepeatingInputStream(final String header, final String body, int bodyRepeats) {
+        this.data = header.getBytes(StandardCharsets.UTF_8);
+        this.body = body.getBytes(StandardCharsets.UTF_8);
+        bodyRepeatsRemaining = bodyRepeats;
+        tempBufferForRead = new byte[1];
+        offset = 0;
+
+    }
+
+    @Override
+    public int read() throws IOException {
+        final int numBytes = read(tempBufferForRead, 0, 1);
+        if (numBytes == 0) {
+            return -1;
+        }
+        return tempBufferForRead[0] & 0xff;
+    }
+
+    @Override
+    public int read(byte @NotNull [] b, int off, int len) {
+        if (len == 0) {
+            return 0;
+        }
+        while (offset == data.length) {
+            if (bodyRepeatsRemaining == 0) {
+                return -1;
+            }
+            data = body;
+            offset = 0;
+            --bodyRepeatsRemaining;
+        }
+        final int currentSize = data.length - offset;
+        final int sizeToUse = Math.min(currentSize, len);
+        System.arraycopy(data, offset, b, off, sizeToUse);
+        offset += sizeToUse;
+        return sizeToUse;
+    }
+}

--- a/src/test/java/io/deephaven/csv/testutil/Sentinels.java
+++ b/src/test/java/io/deephaven/csv/testutil/Sentinels.java
@@ -1,0 +1,14 @@
+package io.deephaven.csv.testutil;
+
+public class Sentinels {
+    public static final byte NULL_BOOLEAN_AS_BYTE = Byte.MIN_VALUE;
+    public static final byte NULL_BYTE = Byte.MIN_VALUE;
+    public static final short NULL_SHORT = Short.MIN_VALUE;
+    public static final int NULL_INT = Integer.MIN_VALUE;
+    public static final long NULL_LONG = Long.MIN_VALUE;
+    public static final float NULL_FLOAT = -Float.MAX_VALUE;
+    public static final double NULL_DOUBLE = -Double.MAX_VALUE;
+    public static final char NULL_CHAR = Character.MAX_VALUE;
+    public static final long NULL_DATETIME_AS_LONG = Long.MIN_VALUE;
+    public static final long NULL_TIMESTAMP_AS_LONG = Long.MIN_VALUE;
+}

--- a/src/test/java/io/deephaven/csv/testutil/StubbornSink.java
+++ b/src/test/java/io/deephaven/csv/testutil/StubbornSink.java
@@ -1,0 +1,56 @@
+package io.deephaven.csv.testutil;
+
+import io.deephaven.csv.sinks.Sink;
+import io.deephaven.csv.sinks.Source;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class StubbornSink<TARRAY> implements Sink<TARRAY>, Source<TARRAY> {
+    private final long timeout;
+    private final CountDownLatch outgoingSinkReady;
+    private final CountDownLatch incomingShutdownRequest;
+    private final CountDownLatch outgoingShutdownComplete;
+
+    public StubbornSink(Duration timeout, CountDownLatch outgoingSinkReady,
+            CountDownLatch incomingShutdownRequest, CountDownLatch outgoingShutdownComplete) {
+        this.timeout = timeout.toMillis();
+        this.outgoingSinkReady = outgoingSinkReady;
+        this.incomingShutdownRequest = incomingShutdownRequest;
+        this.outgoingShutdownComplete = outgoingShutdownComplete;
+    }
+
+    @Override
+    public void write(TARRAY src, boolean[] isNull, long destBegin, long destEnd, boolean appending) {
+        if (destBegin == destEnd) {
+            return;
+        }
+
+        // Notify other cooperating sink that we are inside our "write" stage.
+        outgoingSinkReady.countDown();
+
+        final long expirationTime = System.currentTimeMillis() + timeout;
+        while (true) {
+            long remainingTime = expirationTime - System.currentTimeMillis();
+            try {
+                boolean ignored = incomingShutdownRequest.await(remainingTime, TimeUnit.MILLISECONDS);
+                // Exit infinite loop, regardless of message received or timeout,
+                break;
+            } catch (InterruptedException e) {
+                // Ignore attempts to interrupt me earlier than the timeout.
+            }
+        }
+        outgoingShutdownComplete.countDown();
+    }
+
+    @Override
+    public Object getUnderlying() {
+        return null;
+    }
+
+    @Override
+    public void read(TARRAY dest, boolean[] isNull, long srcBegin, long srcEnd) {
+        // Do nothing.
+    }
+}

--- a/src/test/java/io/deephaven/csv/testutil/SyncState.java
+++ b/src/test/java/io/deephaven/csv/testutil/SyncState.java
@@ -1,0 +1,37 @@
+package io.deephaven.csv.testutil;
+
+public class SyncState {
+    private final int numParticipatingColumns;
+    private final long thresholdSize;
+    private long nextThreshold = 0;
+    private int numWaiters = 0;
+
+    public SyncState(int numParticipatingColumns, long thresholdSize) {
+        this.numParticipatingColumns = numParticipatingColumns;
+        this.thresholdSize = thresholdSize;
+    }
+
+    public synchronized void maybeWait(final int colNum, final long sizeWritten) {
+        while (true) {
+            if (sizeWritten < nextThreshold) {
+                return;
+            }
+
+            if (numWaiters == numParticipatingColumns - 1) {
+                // Everyone else is waiting, so advance the threshold.
+                nextThreshold += thresholdSize;
+                notifyAll();
+                continue;
+            }
+
+            ++numWaiters;
+            try {
+                wait();
+            } catch (InterruptedException ie) {
+                throw new RuntimeException("Interrupted", ie);
+            } finally {
+                --numWaiters;
+            }
+        }
+    }
+}

--- a/src/test/java/io/deephaven/csv/testutil/SynchronizingSink.java
+++ b/src/test/java/io/deephaven/csv/testutil/SynchronizingSink.java
@@ -1,0 +1,31 @@
+package io.deephaven.csv.testutil;
+
+import io.deephaven.csv.sinks.Sink;
+import io.deephaven.csv.sinks.Source;
+
+public class SynchronizingSink<TARRAY> implements Sink<TARRAY>, Source<TARRAY> {
+    private final int colNum;
+    private final SyncState syncState;
+    private long sizeWritten = 0;
+
+    public SynchronizingSink(int colNum, SyncState syncState) {
+        this.colNum = colNum;
+        this.syncState = syncState;
+    }
+
+    @Override
+    public void write(TARRAY src, boolean[] isNull, long destBegin, long destEnd, boolean appending) {
+        sizeWritten += destEnd - destBegin;
+        syncState.maybeWait(colNum, sizeWritten);
+    }
+
+    @Override
+    public Object getUnderlying() {
+        return null;
+    }
+
+    @Override
+    public void read(TARRAY dest, boolean[] isNull, long srcBegin, long srcEnd) {
+        // Do nothing.
+    }
+}

--- a/src/test/java/io/deephaven/csv/testutil/ThrowingSink.java
+++ b/src/test/java/io/deephaven/csv/testutil/ThrowingSink.java
@@ -1,0 +1,37 @@
+package io.deephaven.csv.testutil;
+
+import io.deephaven.csv.sinks.Sink;
+import io.deephaven.csv.sinks.Source;
+
+import java.util.concurrent.CountDownLatch;
+
+public class ThrowingSink<TARRAY> implements Sink<TARRAY>, Source<TARRAY> {
+    private final CountDownLatch incomingSinkReady;
+
+    public ThrowingSink(CountDownLatch incomingSinkReady) {
+        this.incomingSinkReady = incomingSinkReady;
+    }
+
+    @Override
+    public void write(TARRAY src, boolean[] isNull, long destBegin, long destEnd, boolean appending) {
+        if (destBegin == destEnd) {
+            return;
+        }
+        try {
+            incomingSinkReady.await();
+            throw new RuntimeException("synthetic error for testing");
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Interrupted");
+        }
+    }
+
+    @Override
+    public Object getUnderlying() {
+        return null;
+    }
+
+    @Override
+    public void read(TARRAY dest, boolean[] isNull, long srcBegin, long srcEnd) {
+        // Do nothing.
+    }
+}


### PR DESCRIPTION
Up to now, we’ve put pretty much all of our tests in the same large file. The tests rely on a variety of helper classes which are also in the same file. This PR refactors out those utility classes into separate files. It does not introduce any behavioral changes.