### PR TITLE
Permit the configuration of multiple parsers on a per-column basis

### DIFF
--- a/src/main/java/io/deephaven/csv/CsvSpecs.java
+++ b/src/main/java/io/deephaven/csv/CsvSpecs.java
@@ -68,27 +68,54 @@ public abstract class CsvSpecs {
          */
         Builder parsers(Iterable<? extends Parser<?>> elements);
 
+
         /**
-         * Used to force a specific parser for a specific column, specified by column name. Specifying a parser forgoes
-         * column inference for that column. If {@link #putParserForName} and {@link #putParserForIndex} both refer to
-         * the same column, {@link #putParserForName} takes priority.
-         * 
+         * Used to force a single parser for a specific column, specified by column name. Specifying a single parser
+         * forgoes type inference for that column. If {@link #putParserForName} and {@link #putParserForIndex} both
+         * refer to the same column, {@link #putParserForName} takes priority.
+         *
          * @param columnName The column name
          * @param parser The parser
          * @return self after modifying the parser property for the given columnName.
          */
-        Builder putParserForName(String columnName, Parser<?> parser);
+        default Builder putParserForName(String columnName, Parser<?> parser) {
+            return putParsersForName(columnName, Collections.singletonList(parser));
+        }
 
         /**
-         * Used to force a specific parser for a specific column, specified by 0-based column index. Specifying a parser
-         * forgoes column inference for that column. If {@link #putParserForName} and {@link #putParserForIndex} both
-         * refer to the same column, {@link #putParserForName} takes priority.
-         * 
+         * Used to force a single parser for a specific column, specified by 0-based column index. Specifying a single
+         * parser forgoes type inference for that column. If {@link #putParserForName} and {@link #putParserForIndex}
+         * both refer to the same column, {@link #putParserForName} takes priority.
+         *
          * @param index The column index
          * @param parser The parser
          * @return self after modifying the parser property for the given column index.
          */
-        Builder putParserForIndex(int index, Parser<?> parser);
+        default Builder putParserForIndex(int index, Parser<?> parser) {
+            return putParsersForIndex(index, Collections.singletonList(parser));
+        }
+
+        /**
+         * Used to force a specific set of parsers for a specific column, specified by column name. If
+         * {@link #putParsersForName} and {@link #putParsersForIndex} both refer to the same column,
+         * {@link #putParsersForName} takes priority.
+         * 
+         * @param columnName The column name
+         * @param elements The parsers
+         * @return self after modifying the parser property for the given columnName.
+         */
+        Builder putParsersForName(String columnName, List<Parser<?>> elements);
+
+        /**
+         * Used to force a specific set of parsers for a specific column, specified by column name. If
+         * {@link #putParsersForName} and {@link #putParsersForIndex} both refer to the same column,
+         * {@link #putParsersForName} takes priority.
+         * 
+         * @param index The column index
+         * @param elements The parsers
+         * @return self after modifying the parser property for the given column index.
+         */
+        Builder putParsersForIndex(int index, List<Parser<?>> elements);
 
         /**
          * The default collection of strings that means "null value" in the input. These defaults are used for a column
@@ -468,18 +495,18 @@ public abstract class CsvSpecs {
     }
 
     /**
-     * See {@link Builder#putParserForName}.
+     * See {@link Builder#putParsersForName}.
      * 
      * @return A map of the client-specified parsers, keyed by column name.
      */
-    public abstract Map<String, Parser<?>> parserForName();
+    public abstract Map<String, List<Parser<?>>> parsersForName();
 
     /**
-     * See {@link Builder#putParserForIndex}.
+     * See {@link Builder#putParsersForIndex}.
      * 
      * @return A map of the client-specified parsers, keyed by column index.
      */
-    public abstract Map<Integer, Parser<?>> parserForIndex();
+    public abstract Map<Integer, List<Parser<?>>> parsersForIndex();
 
     /**
      * See {@link Builder#nullValueLiterals}.

--- a/src/main/java/io/deephaven/csv/reading/CsvReader.java
+++ b/src/main/java/io/deephaven/csv/reading/CsvReader.java
@@ -247,13 +247,13 @@ public final class CsvReader {
      */
     private static List<Parser<?>> calcParsersToUse(final CsvSpecs specs, final String columnName,
             final int columnIndex) {
-        Parser<?> specifiedParser = specs.parserForName().get(columnName);
-        if (specifiedParser != null) {
-            return Collections.singletonList(specifiedParser);
+        List<Parser<?>> specifiedParsers = specs.parsersForName().get(columnName);
+        if (specifiedParsers != null) {
+            return specifiedParsers;
         }
-        specifiedParser = specs.parserForIndex().get(columnIndex);
-        if (specifiedParser != null) {
-            return Collections.singletonList(specifiedParser);
+        specifiedParsers = specs.parsersForIndex().get(columnIndex);
+        if (specifiedParsers != null) {
+            return specifiedParsers;
         }
         return specs.parsers();
     }

--- a/src/test/java/io/deephaven/csv/PerColumnParsersTest.java
+++ b/src/test/java/io/deephaven/csv/PerColumnParsersTest.java
@@ -1,0 +1,46 @@
+package io.deephaven.csv;
+
+import io.deephaven.csv.parsers.*;
+import io.deephaven.csv.testutil.*;
+import io.deephaven.csv.util.CsvReaderException;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+public class PerColumnParsersTest {
+    /**
+     * Tests per-column custom parser inferencing.
+     */
+    @Test
+    public void testPerColumnParsers() throws CsvReaderException {
+        // Has four columns with the same values: 0, 10, 5000
+        // The columns are configured with different parser inferencers
+        // Col0: byte, string
+        // Col1: byte, short, string
+        // Col2: byte, int, string
+        // Col3: default parser, which is set to byte, double, string
+        final String input = "Col0,Col1,Col2,Col3\n" +
+                "0, 0, 0, 0\n" +
+                "10, 10, 10, 10\n" +
+                "5000, 5000, 5000, 5000\n";
+
+        final List<Parser<?>> col0Parsers = Arrays.asList(Parsers.BYTE, Parsers.STRING);
+        final List<Parser<?>> col1Parsers = Arrays.asList(Parsers.BYTE, Parsers.SHORT, Parsers.STRING);
+        final List<Parser<?>> col2Parsers = Arrays.asList(Parsers.BYTE, Parsers.INT, Parsers.STRING);
+        final List<Parser<?>> defaultParsers = Arrays.asList(Parsers.BYTE, Parsers.DOUBLE, Parsers.STRING);
+
+        final ColumnSet expected =
+                ColumnSet.of(
+                        Column.ofRefs("Col0", "0", "10", "5000"),
+                        Column.ofValues("Col1", (short) 0, (short) 10, (short) 5000),
+                        Column.ofValues("Col2", (int) 0, (int) 10, (int) 5000),
+                        Column.ofValues("Col3", (double) 0, (double) 10, (double) 5000));
+
+        CsvTestUtil.invokeTest(CsvTestUtil.defaultCsvBuilder()
+                .putParsersForIndex(0, col0Parsers)
+                .putParsersForIndex(1, col1Parsers)
+                .putParsersForIndex(2, col2Parsers)
+                .parsers(defaultParsers)
+                .build(), input, expected);
+    }
+}


### PR DESCRIPTION
~~** NOTE TO REVIEWERS ** this PR is downstream of https://github.com/deephaven/deephaven-csv/pull/282 .  That PR should be merged before you look at this PR.~~

Prior to this change, the library allowed for one set of inferencing parsers, with the ability to set a single parser override on a per-column basis.

After this change, each column can have its own set of parsers.

To the old methods:
- putParserForName
- putParserForIndex

We add new methods
- putParsersForName
- putParsersForIndex