### PR TITLE
fix(build): actually run tests

### DIFF
--- a/buildSrc/src/main/groovy/io.deephaven.csv.java-toolchain-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.deephaven.csv.java-toolchain-conventions.gradle
@@ -24,9 +24,11 @@ def registerTest = version -> {
     project.tasks.register("testOn${version}", Test) { test ->
         test.group = 'verification'
         test.description = "Runs the test suite with Java ${version}."
-        test.javaLauncher.set javaToolchains.launcherFor {
+        test.javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(version)
         }
+        test.testClassesDirs = testing.suites.test.sources.output.classesDirs
+        test.classpath = testing.suites.test.sources.runtimeClasspath
     }
 }
 


### PR DESCRIPTION
This fixes an oversight in upgrading to gradle 9 in #286

See https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#test_tasks_may_no_longer_execute_expected_tests