### PR TITLE
fix(deephaven/csv): DH-20875: Always use explicit UTF-8 encoding when calling String constructor

### DIFF
--- a/src/main/java/io/deephaven/csv/containers/ByteSlice.java
+++ b/src/main/java/io/deephaven/csv/containers/ByteSlice.java
@@ -2,6 +2,8 @@ package io.deephaven.csv.containers;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * An object that represents a slice of byte data. This object is intended to be reusable. It implements
  * {@link CharSequence} because there are a few special cases (e.g. calling out to certain libraries) where it is
@@ -159,6 +161,6 @@ public final class ByteSlice implements CharSequence {
     @NotNull
     public String toString() {
         final int size = size();
-        return size == 0 ? "" : new String(data, begin, size);
+        return size == 0 ? "" : new String(data, begin, size, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/io/deephaven/csv/reading/CsvReader.java
+++ b/src/main/java/io/deephaven/csv/reading/CsvReader.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -50,8 +51,17 @@ public final class CsvReader {
     private CsvReader() {}
 
     /**
-     * Read the data.
-     *
+     * Read the data. Note that the InputStream 'stream' is assumed to be encoded as UTF-8. (A stream of pure ASCII is
+     * also acceptable, because ASCII is a subset of UTF-8). If your stream is encoded in some other character set, e.g.
+     * ISO-8859-1, you will need to convert it to UTF-8 before passing it to this method. You can conveniently do this
+     * with the ReaderInputStream from Apache Commons:
+     * 
+     * <pre>
+     * InputStream sourceStream = new FileInputStream("input_iso-8859-1.txt");
+     * Reader reader = new InputStreamReader(sourceStream, StandardCharsets.ISO_8859_1);
+     * InputStream utf8Stream = new ReaderInputStream(reader, StandardCharsets.UTF_8);
+     * </pre>
+     * 
      * @param specs A {@link CsvSpecs} object providing options for the parse.
      * @param stream The input data, encoded in UTF-8.
      * @param sinkFactory A factory that can provide Sink&lt;T&gt; of all appropriate types for the output data. Once

--- a/src/main/java/io/deephaven/csv/reading/headers/DelimitedHeaderFinder.java
+++ b/src/main/java/io/deephaven/csv/reading/headers/DelimitedHeaderFinder.java
@@ -8,6 +8,7 @@ import io.deephaven.csv.util.CsvReaderException;
 import io.deephaven.csv.util.MutableBoolean;
 import io.deephaven.csv.util.MutableObject;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -47,7 +48,8 @@ public class DelimitedHeaderFinder {
                 }
                 --skipCount;
             }
-            headersToUse = Arrays.stream(headerRow).map(String::new).toArray(String[]::new);
+            headersToUse = Arrays.stream(headerRow).map(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                    .toArray(String[]::new);
         }
 
         // Whether or not the input had headers, maybe override with client-specified headers.


### PR DESCRIPTION
Fixes https://github.com/deephaven/deephaven-csv/issues/278 and moots https://github.com/deephaven/deephaven-csv/pull/279 (until such time as we might feel like relaxing the UTF-8 restriction).

Summary of the bug investigation and a long discussion with Devin about alternatives.

The actual bug is different from the backstory, but I’ll give the backstory first.

Backstory: the library assumes that the `InputStream` is encoded in UTF-8, and this assumption is embedded pretty deeply in the code. For the foreseeable future, callers have to pass us a UTF-8 encoded `InputStream`. (Or, degenerately, an ASCII-encoded `InputStream`, because ASCII is a subset of UTF-8). If callers have data encoded in some other character set, say, ISO-8859-1, it’s up to them to re-encode it before it reaches us. Fortunately this is very easy to do in something like Apache Commons:

```
     InputStream sourceStream = new FileInputStream("input_iso-8859-1.txt");
     Reader reader = new InputStreamReader(sourceStream, StandardCharsets.ISO_8859_1);
     InputStream utf8Stream = new ReaderInputStream(reader, StandardCharsets.UTF_8);
```

Now this has little to do with the actual bug.

The actual bug is that there are two places in the code where we have UTF-8 bytes and we need to convert them back to Java Strings. When we do this we call one of the String constructors that takes a byte array. The problem is that these String constructors don’t assume UTF-8; rather they take their encoding from the “platform’s default charset”, which can be overridden by this -DFile.encoding=xxx flag, like the OP is doing. The solution for us is simply to call a different String constructor that explicitly specifies `StandardCharsets.UTF_8`

Put another way, the original poster had a UTF-8 encoded InputStream (as expected) and in the normal case we would convert the UTF-8 bytes back to Strings using the `String(byte[])` or `String(byte[], int, int)` constructors. But what happened to OP is that they changed the platform default charset by using the `-Dfile.encoding=US-ASCII` flag to the JVM. This changed the behavior of the specific String constructor we were using: it caused that constructor to take the UTF-8 bytes it was being given and try to interpret them as US-ASCII.

Simply specifying the charset in the String constructor (namely `String(bytes[], Charset)` and `String(bytes[], int, int, Charset)` should fix the OP's bug.

We also add a comment (beyond the scope of the OP's bug report) that it's relatively easy to adapt other character sets on input, if people need to do so.
