### PR TITLE
chore: Update dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,21 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 99
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(github-actions)"
+    assignees:
+      - "devinrsmith"
+      - "kosak"
   - package-ecosystem: "gradle"
     directory: "/"
+    open-pull-requests-limit: 99
     schedule:
-      interval: "daily"
-
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(gradle)"
+    assignees:
+      - "devinrsmith"
+      - "kosak"


### PR DESCRIPTION
* Updates the dependabot limit so it can open more than 5 outstanding pull requests
* Add an appropriate commit prefix
* Add assignees
* Check weekly (instead of daily)

 This is similar to the settings from [deephaven-core](https://github.com/deephaven/deephaven-core/blob/v41.0/.github/dependabot.yml).