### PR TITLE
fix: DH-21390: make timeout longer for bug52() so running with coverage succeeds

### DIFF
--- a/src/test/java/io/deephaven/csv/CsvReaderTest.java
+++ b/src/test/java/io/deephaven/csv/CsvReaderTest.java
@@ -83,7 +83,7 @@ public class CsvReaderTest {
      * bug exists, the library hangs (and this test times out). When the bug is fixed, the test succeeds.
      */
     @Test
-    @Timeout(value = 30)
+    @Timeout(value = 90)
     public void bug52() throws CsvReaderException {
         final int numRows = 50_000_000;
         final RepeatingInputStream inputStream =


### PR DESCRIPTION
Running with code coverage tends to slow down the code quite a bit. This change makes the timeout for `bug52()` more generous so code coverage doesn't time out. In practice, it does not affect the normal behavior of the test, which runs relatively quickly.