### PR TITLE
feat: DH-21391: Add unit test that highlights edge cases of float vs double parsing

### DIFF
--- a/src/test/java/io/deephaven/csv/testutil/ParserFidelityTest.java
+++ b/src/test/java/io/deephaven/csv/testutil/ParserFidelityTest.java
@@ -102,12 +102,11 @@ public class ParserFidelityTest {
         }
 
         if (fidelity == ParseFidelity.PARSE_FAIL) {
-            Assertions.assertThat(failed);
+            Assertions.assertThat(failed).isTrue();
             return;
         }
 
-        Assertions.assertThat(!failed);
-        assert result != null; // make linter happy
+        Assertions.assertThat(failed).isFalse();
 
         Assertions.assertThat(result.numCols()).isEqualTo(1);
         Assertions.assertThat(result.numRows()).isEqualTo(1);


### PR DESCRIPTION
This is a subtle topic, but there are a a few edge cases where users will get slightly different floating point answers than expected when using our library. These all boil down to the same reasons:

There are cases where the Java expression `Float.parse(s)` can differ from `(float)Double.parse(s)`.  We use (the equivalent of) the latter everywhere for type inferencing reasons and because our double parser is a third-party library that is very fast.

We are already aware of this, and we provide `FloatStrictParser` for users that want strict behavior that is exactly `Float.parse(s)`.

This issue adds a unit test that exercises `FloatStrictParser` and highlights its differences.